### PR TITLE
fix: Resolve interface with class definition

### DIFF
--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -166,6 +166,7 @@ class DiContainer implements DiContainerInterface
     {
         if (!isset($this->definitionCache[$id])) {
             $isSingletonDefault = $this->config?->isSingletonServiceDefault() ?? false;
+            $isIdInterface = \interface_exists($id);
 
             if (null === $rawDefinition) {
                 if (\class_exists($id)) {
@@ -175,7 +176,7 @@ class DiContainer implements DiContainerInterface
                             : new DiContainerDefinition($id, $id, $isSingletonDefault, []);
                 }
 
-                if (\interface_exists($id) && $this->config?->isUseAttribute()
+                if ($isIdInterface && $this->config?->isUseAttribute()
                     && $service = Service::makeFromReflection(new \ReflectionClass($id))) {
                     return $this->definitionCache[$id] = new DiContainerDefinition($id, $service->id, $service->isSingleton, $service->arguments);
                 }
@@ -195,7 +196,11 @@ class DiContainer implements DiContainerInterface
                 return $this->definitionCache[$id] = new DiContainerDefinition($id, $definition, $isSingleton, $arguments);
             }
 
-            if (\is_string($definition) && (\class_exists($definition) || \interface_exists($id))) {
+            if (\is_string($definition) && (\class_exists($definition) || $isIdInterface)) {
+                if ($isIdInterface && [] === $arguments && isset($this->definitions[$definition])) {
+                    $arguments = $this->autowireDefinition($definition, $this->definitions[$definition])->arguments;
+                }
+
                 return $this->definitionCache[$id] = new DiContainerDefinition($id, $definition, $isSingleton, $arguments);
             }
 

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -144,6 +144,7 @@ class ContainerTest extends TestCase
 
         $this->assertEquals('first, second', $repository->all());
         $this->assertNull($repository->db->store);
+        $this->assertInstanceOf(Interfaces\CacheTypeInterface::class, $repository->db->cache);
     }
 
     public function testResolveByInterfaceWithNamedArgClassInstance(): void
@@ -250,6 +251,22 @@ class ContainerTest extends TestCase
 
         $this->assertEquals(60, $c->get(Interfaces\SumInterface::class)->add(10));
         $this->assertEquals(20, $c->get(Classes\Sum::class)->add(10));
+    }
+
+    public function testByInterfaceByClassAndClassWithParams(): void
+    {
+        $definitions = [
+            Interfaces\SumInterface::class => Classes\Sum::class,
+            Classes\Sum::class => [
+                'arguments' => [
+                    'init' => 10,
+                ],
+            ],
+        ];
+
+        $c = new DiContainer($definitions, $this->diContainerConfig);
+
+        $this->assertEquals(20, $c->get(Interfaces\SumInterface::class)->add(10));
     }
 
     public function testByInterfaceOnly(): void


### PR DESCRIPTION
Не работает определение
```php
    ClassInterface::class => ClassFirst::class,

    ClassFirst::class => [
        'arguments' => [
            'file' => '@app.logger.file'
        ],
    ],
```
не учитывается созданное определение с аргументами на класс.