### PR TITLE
Refactor and Optimization

### DIFF
--- a/src/DiContainer/Attributes/DiFactory.php
+++ b/src/DiContainer/Attributes/DiFactory.php
@@ -5,24 +5,40 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Attributes;
 
 use Kaspi\DiContainer\Exception\AutowiredAttributeException;
+use Kaspi\DiContainer\Interfaces\Attributes\DiAttributeInterface;
 use Kaspi\DiContainer\Interfaces\DiFactoryInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
-final class DiFactory
+final class DiFactory implements DiAttributeInterface
 {
     /**
      * @param class-string<DiFactoryInterface> $id
      */
-    public function __construct(public string $id, public array $arguments = [], public bool $isSingleton = false)
+    public function __construct(private string $id, private array $arguments = [], private bool $isSingleton = false)
     {
-        \is_a($this->id, DiFactoryInterface::class, true)
-            || throw new AutowiredAttributeException("Parameter '{$this->id}' must be implement '".DiFactoryInterface::class."' interface");
+        \is_a($id, DiFactoryInterface::class, true)
+            || throw new AutowiredAttributeException("Parameter '{$id}' must be implement '".DiFactoryInterface::class."' interface");
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function isSingleton(): bool
+    {
+        return $this->isSingleton;
     }
 
     /**
-     * @return array<int, DiFactory>
+     * @return \Generator<DiFactory>
      */
-    public static function makeFromReflection(\ReflectionClass|\ReflectionParameter $parameter): array
+    public static function makeFromReflection(\ReflectionClass|\ReflectionParameter $parameter): \Generator
     {
         $attributes = $parameter->getAttributes(self::class);
 
@@ -34,6 +50,8 @@ final class DiFactory
             throw new AutowiredAttributeException('The attribute #[DiFactory] can only be applied once per non-variadic parameter.');
         }
 
-        return \array_map(static fn (\ReflectionAttribute $attribute) => $attribute->newInstance(), $attributes);
+        foreach ($attributes as $attribute) {
+            yield $attribute->newInstance();
+        }
     }
 }

--- a/src/DiContainer/Attributes/Service.php
+++ b/src/DiContainer/Attributes/Service.php
@@ -4,13 +4,30 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Attributes;
 
+use Kaspi\DiContainer\Interfaces\Attributes\DiAttributeInterface;
+
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class Service
+final class Service implements DiAttributeInterface
 {
     /**
      * @param class-string|string $id class name or container reference
      */
-    public function __construct(public string $id, public array $arguments = [], public bool $isSingleton = false) {}
+    public function __construct(private string $id, private array $arguments = [], private bool $isSingleton = false) {}
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function isSingleton(): bool
+    {
+        return $this->isSingleton;
+    }
 
     public static function makeFromReflection(\ReflectionClass $parameter): ?self
     {

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -18,9 +18,10 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface
     /**
      * @throws AutowiredExceptionInterface
      */
-    public function __construct(private string $definition, private bool $isSingleton, array $arguments = [])
+    public function __construct(ContainerInterface $container, private string $definition, private bool $isSingleton, array $arguments = [])
     {
         try {
+            $this->container = $container;
             $this->reflectionClass = new \ReflectionClass($this->definition);
             $this->reflectionClass->isInstantiable()
                 || throw new AutowiredException(\sprintf('The [%s] class is not instantiable', $definition));
@@ -37,13 +38,13 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface
         return $this->isSingleton;
     }
 
-    public function invoke(ContainerInterface $container, ?bool $useAttribute): mixed
+    public function invoke(?bool $useAttribute): mixed
     {
         if ([] === $this->reflectionParameters) {
             return $this->reflectionClass->newInstance();
         }
 
-        $args = $this->resolveParameters($container, $useAttribute);
+        $args = $this->resolveParameters($useAttribute);
 
         return $this->reflectionClass->newInstanceArgs($args);
     }

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -41,7 +41,7 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface
     public function invoke(?bool $useAttribute): mixed
     {
         if ([] === $this->reflectionParameters) {
-            return $this->reflectionClass->newInstance();
+            return $this->reflectionClass->newInstanceWithoutConstructor();
         }
 
         $args = $this->resolveParameters($useAttribute);

--- a/src/DiContainer/DiDefinition/DiDefinitionCallable.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionCallable.php
@@ -16,8 +16,9 @@ final class DiDefinitionCallable implements DiDefinitionAutowireInterface
      */
     private $definition;
 
-    public function __construct(callable $definition, private bool $isSingleton, array $arguments = [])
+    public function __construct(ContainerInterface $container, callable $definition, private bool $isSingleton, array $arguments = [])
     {
+        $this->container = $container;
         $this->definition = $definition;
         $this->reflectionParameters = $this->reflectParameters();
         $this->arguments = $arguments;
@@ -28,16 +29,15 @@ final class DiDefinitionCallable implements DiDefinitionAutowireInterface
         return $this->isSingleton;
     }
 
-    public function invoke(ContainerInterface $container, ?bool $useAttribute): mixed
+    public function invoke(?bool $useAttribute): mixed
     {
         if ([] === $this->reflectionParameters) {
             return \call_user_func($this->definition);
         }
 
-        $resolvedArgs = $this->resolveParameters($container, $useAttribute);
-        $args = \array_values($resolvedArgs);
+        $resolvedArgs = $this->resolveParameters($useAttribute);
 
-        return \call_user_func_array($this->definition, $args);
+        return \call_user_func_array($this->definition, $resolvedArgs);
     }
 
     public function getDefinition(): callable

--- a/src/DiContainer/Interfaces/Attributes/DiAttributeInterface.php
+++ b/src/DiContainer/Interfaces/Attributes/DiAttributeInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\Attributes;
+
+interface DiAttributeInterface
+{
+    public function getId(): string;
+
+    public function isSingleton(): bool;
+
+    public function getArguments(): array;
+}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionAutowireInterface.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 
-use Kaspi\DiContainer\Exception\CallCircularDependency;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowiredExceptionInterface;
 use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 interface DiDefinitionAutowireInterface extends DiDefinitionInterface
@@ -18,7 +16,6 @@ interface DiDefinitionAutowireInterface extends DiDefinitionInterface
      * @throws AutowiredExceptionInterface
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
-     * @throws CallCircularDependency
      */
-    public function invoke(ContainerInterface $container, ?bool $useAttribute): mixed;
+    public function invoke(?bool $useAttribute): mixed;
 }

--- a/tests/Unit/CallCircularDependency/CallCircularDependencyTest.php
+++ b/tests/Unit/CallCircularDependency/CallCircularDependencyTest.php
@@ -44,7 +44,7 @@ class CallCircularDependencyTest extends TestCase
     public function testCircularDependencyCallCircularDependencyInClass(): void
     {
         $this->expectException(CallCircularDependency::class);
-        $this->expectExceptionMessageMatches('/Trying call cyclical dependency.+FirstClass.*SecondClass.+FirstClass/');
+        $this->expectExceptionMessageMatches('/Trying call cyclical dependency.+FirstClass.+SecondClass.+FirstClass/');
 
         (new DiContainerFactory())->make()->get(FirstClass::class);
     }

--- a/tests/Unit/CallCircularDependency/CallCircularDependencyTest.php
+++ b/tests/Unit/CallCircularDependency/CallCircularDependencyTest.php
@@ -44,6 +44,7 @@ class CallCircularDependencyTest extends TestCase
     public function testCircularDependencyCallCircularDependencyInClass(): void
     {
         $this->expectException(CallCircularDependency::class);
+        $this->expectExceptionMessageMatches('/Trying call cyclical dependency.+FirstClass.*SecondClass.+FirstClass/');
 
         (new DiContainerFactory())->make()->get(FirstClass::class);
     }

--- a/tests/Unit/Callable/CallableMakeFromAbstractTest.php
+++ b/tests/Unit/Callable/CallableMakeFromAbstractTest.php
@@ -53,10 +53,10 @@ class CallableMakeFromAbstractTest extends TestCase
         ]);
 
         $callable = $this->callableParser::make(SimpleInvokeClass::class, $container);
-        $d = new DiDefinitionCallable($callable, true);
+        $d = new DiDefinitionCallable($container, $callable, true);
 
         $this->assertIsCallable($d->getDefinition());
-        $this->assertEquals('Hello Piter!', $d->invoke($container, true));
+        $this->assertEquals('Hello Piter!', $d->invoke(true));
     }
 
     public function testInvokeClassAsInstance(): void
@@ -64,11 +64,11 @@ class CallableMakeFromAbstractTest extends TestCase
         $definition = [new SimpleInvokeClass(name: 'Vasiliy'), 'hello'];
         $container = (new DiContainerFactory())->make();
         $callable = $this->callableParser::make($definition, $container);
-        $d = new DiDefinitionCallable($callable, true);
+        $d = new DiDefinitionCallable($container, $callable, true);
 
         $this->assertIsCallable($d->getDefinition());
         $this->assertEquals('Vasiliy hello!', \call_user_func($d->getDefinition()));
-        $this->assertEquals('Vasiliy hello!', $d->invoke($container, true));
+        $this->assertEquals('Vasiliy hello!', $d->invoke(true));
     }
 
     public function testDefinitionWithNonStaticMethodAsString(): void
@@ -80,11 +80,11 @@ class CallableMakeFromAbstractTest extends TestCase
         $definition = 'Tests\Unit\Callable\Fixtures\SimpleInvokeClass::hello';
         $callable = $this->callableParser::make($definition, $container);
 
-        $d = new DiDefinitionCallable($callable, true);
+        $d = new DiDefinitionCallable($container, $callable, true);
 
         $this->assertIsCallable($d->getDefinition());
         $this->assertEquals('Alex hello!', \call_user_func_array($d->getDefinition(), []));
-        $this->assertEquals('Alex hello!', $d->invoke($container, true));
+        $this->assertEquals('Alex hello!', $d->invoke(true));
     }
 
     public function testDefinitionWithNonExistMethodAsString(): void
@@ -150,10 +150,10 @@ class CallableMakeFromAbstractTest extends TestCase
         $container = (new DiContainerFactory())->make();
         $callable = $this->callableParser::make($definition, $container);
 
-        $d = new DiDefinitionCallable($callable, true);
+        $d = new DiDefinitionCallable($container, $callable, true);
 
         $this->assertIsCallable($d->getDefinition());
-        $this->assertEquals('I am foo static', $d->invoke($container, true));
+        $this->assertEquals('I am foo static', $d->invoke(true));
         $this->assertEquals('I am foo static', \call_user_func_array($d->getDefinition(), []));
     }
 
@@ -175,10 +175,10 @@ class CallableMakeFromAbstractTest extends TestCase
         $definition = '\Tests\Unit\Callable\Fixtures\testFunction';
         $callable = $this->callableParser::make($definition, $container);
 
-        $d = new DiDefinitionCallable($callable, false);
+        $d = new DiDefinitionCallable($container, $callable, false);
 
         $this->assertEquals('\Tests\Unit\Callable\Fixtures\testFunction', $d->getDefinition());
         $this->assertFalse($d->isSingleton());
-        $this->assertEquals('x:i:0;a:2:{i:0;s:4:"🎃";i:1;s:4:"🎈";};m:a:0:{}', $d->invoke($container, true));
+        $this->assertEquals('x:i:0;a:2:{i:0;s:4:"🎃";i:1;s:4:"🎈";};m:a:0:{}', $d->invoke(true));
     }
 }

--- a/tests/Unit/Definition/DiDefinitionAutowireTestTest.php
+++ b/tests/Unit/Definition/DiDefinitionAutowireTestTest.php
@@ -25,7 +25,7 @@ class DiDefinitionAutowireTestTest extends TestCase
         $this->expectException(AutowiredExceptionInterface::class);
         $this->expectExceptionMessage('Class "aaa" does not exist');
 
-        new DiDefinitionAutowire('aaa', true);
+        new DiDefinitionAutowire(new DiContainer(), 'aaa', true);
     }
 
     public function testDefinitionWithPrivateConstructor(): void
@@ -33,15 +33,15 @@ class DiDefinitionAutowireTestTest extends TestCase
         $this->expectException(AutowiredExceptionInterface::class);
         $this->expectExceptionMessage('class is not instantiable');
 
-        new DiDefinitionAutowire(PrivateConstructor::class, true);
+        new DiDefinitionAutowire(new DiContainer(), PrivateConstructor::class, true);
     }
 
     public function testDefinitionWithoutConstructor(): void
     {
         $container = new DiContainer();
 
-        $definition = new DiDefinitionAutowire(WithoutConstructor::class, true);
-        $class = $definition->invoke($container, false);
+        $definition = new DiDefinitionAutowire($container, WithoutConstructor::class, true);
+        $class = $definition->invoke(false);
 
         $this->assertInstanceOf(WithoutConstructor::class, $class);
         $this->assertEquals('Tests\Unit\Definition\Fixtures\WithoutConstructor', $definition->getDefinition());
@@ -52,6 +52,6 @@ class DiDefinitionAutowireTestTest extends TestCase
         $this->expectException(AutowiredExceptionInterface::class);
         $this->expectExceptionMessage('class is not instantiable');
 
-        new DiDefinitionAutowire(FreeInterface::class, true);
+        new DiDefinitionAutowire(new DiContainer(), FreeInterface::class, true);
     }
 }

--- a/tests/Unit/Definition/DiDefinitionCallableTest.php
+++ b/tests/Unit/Definition/DiDefinitionCallableTest.php
@@ -26,8 +26,8 @@ class DiDefinitionCallableTest extends TestCase
     {
         $container = (new DiContainerFactory())->make(['service' => SimpleService::class]);
 
-        $callable = new DiDefinitionCallable(CallableStaticMethodWithArgument::class.'::makeSomething', false);
-        $res = $callable->invoke($container, false);
+        $callable = new DiDefinitionCallable($container, CallableStaticMethodWithArgument::class.'::makeSomething', false);
+        $res = $callable->invoke(false);
 
         $this->assertEquals('Tests\Unit\Definition\Fixtures\SimpleService:Tests\Unit\Definition\Fixtures\WithoutConstructor:ok', $res);
     }


### PR DESCRIPTION
-  Добавить интерфейс для всех атрибутов в `Kaspi\DiContainer\Attributes`
- Для интерейса `Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface::invoke` убрать аргумент $container и переместить в конструтор класса реализующего интерфейс.
- Проверсти оптимизацию кода в `src/DiContainer/DiDefinition/ParametersResolverTrait.php`