### PR TITLE
feat: [DiDefinition] Rename class DiDefinitionReference

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -170,18 +170,18 @@ var_dump($container->get('services.one') instanceof App\Services\ServiceOne); //
 >   'services.one' => static fn () => new App\Services\ServiceOne(apiKey: 'my-api-key'),
 > ];
 > ```
-##### diReference - объявление аргумента или определения как ссылки на другой идентификатор контейнера.
+##### diGet - объявление аргумента или определения как ссылки на другой идентификатор контейнера.
 
 ```php
-use function \Kaspi\DiContainer\diReference;
+use function \Kaspi\DiContainer\diGet;
  
-diReference(string $containerIdentifier)
+diGet(string $containerIdentifier)
 ```
 Пример:
 ```php
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diCallable;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 $definitions = [
     'services.env-dsn' => diCallable(
@@ -197,14 +197,14 @@ $definitions = [
     // ...
 
     diAutowire(\PDO::class)
-        ->addArgument('dsn', diReference('services.env-dsn')), // ссылка на определение
+        ->addArgument('dsn', diGet('services.env-dsn')), // ссылка на определение
 ];
 ```
 
 ## Внедрение значений зависимостей аргументов по ссылке на другой идентификатор контейнера.
 
 Для внедрения зависимостей в аргументы по ссылке используется
-функция-хэлпер [diReference](#direference).
+функция-хэлпер [diGet](#diget---объявление-аргумента-или-определения-как-ссылки-на-другой-идентификатор-контейнера).
 
 ```php
 // Объявление класса
@@ -225,7 +225,7 @@ use App\{MyUsers, MyEmployers};
 use Kaspi\DiContainer\DiContainerFactory;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 $definitions = [
     'data' => ['user1', 'user2'],
@@ -234,12 +234,12 @@ $definitions = [
     
     // внедрение зависимости аргумента по ссылке на контейнер-id
     diAutowire(App\MyUsers::class)
-        ->addArgument('users', diReference('data'))
+        ->addArgument('users', diGet('data'))
         ->addArgument('type', 'Some value'),
     diAutowire(App\MyEmployers::class)
         // добавить много аргументов за один раз
         ->addArguments([
-            'employers' => diReference('data'),
+            'employers' => diGet('data'),
             'type' => 'Other value',
         ]),
 ];
@@ -375,7 +375,7 @@ print $myClass->file; // /var/log/app.log
 // Определения для DiContainer - отдельно класс и реализации.
 use App\{ClassFirst, ClassInterface};
 use Kaspi\DiContainer\DiContainerFactory;
-use function Kaspi\DiContainer\{diAutowire, diReference};
+use function Kaspi\DiContainer\{diAutowire, diGet};
 
 $classesDefinitions = [
     diAutowire(ClassFirst::class)
@@ -385,7 +385,7 @@ $classesDefinitions = [
 // ... many definitions ...
 
 $interfacesDefinitions = [
-    ClassInterface::class => diReference(ClassFirst::class),
+    ClassInterface::class => diGet(ClassFirst::class),
 ];
 
 $container = (new DiContainerFactory())->make(
@@ -526,7 +526,7 @@ class RuleGenerator {
 // определения для контейнера
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\DiContainerFactory;
-use function Kaspi\DiContainer\{diAutowire, diReference};
+use function Kaspi\DiContainer\{diAutowire, diGet};
 
 $definition = [
     'ruleC' => diAutowire(App\Rules\RuleC::class),
@@ -536,7 +536,7 @@ $definition = [
             value: [ // <-- обернуть параметры в массив для variadic типов если их несколько.
                 diAutowire(App\Rules\RuleB::class),
                 diAutowire(App\Rules\RuleA::class),
-                diReference('ruleC'), // <-- получение по ссылке
+                diGet('ruleC'), // <-- получение по ссылке
             ], // <-- обернуть параметры в массив если их несколько.            
         )
 ];

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -6,7 +6,7 @@ namespace Kaspi\DiContainer;
 
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
-use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\CallCircularDependencyException;
 use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
@@ -242,7 +242,7 @@ class DiContainer implements DiContainerInterface, DiContainerCallInterface
 
             $rawDefinition = $this->definitions[$id];
 
-            if ($rawDefinition instanceof DiDefinitionReference) {
+            if ($rawDefinition instanceof DiDefinitionGet) {
                 $this->checkCyclicalDependencyCall($rawDefinition->getDefinition());
                 $this->resolvingDependencies[$rawDefinition->getDefinition()] = true;
 

--- a/src/DiContainer/DiDefinition/DiDefinitionGet.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionGet.php
@@ -7,7 +7,7 @@ namespace Kaspi\DiContainer\DiDefinition;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 
-final class DiDefinitionReference implements DiDefinitionInterface
+final class DiDefinitionGet implements DiDefinitionInterface
 {
     /**
      * @param non-empty-string $containerIdentifier

--- a/src/DiContainer/Traits/ParametersResolverTrait.php
+++ b/src/DiContainer/Traits/ParametersResolverTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Traits;
 
-use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Exception\CallCircularDependencyException;
@@ -176,7 +176,7 @@ trait ParametersResolverTrait
      */
     protected function resolveInputArgument(\ReflectionParameter $parameter, mixed $argumentDefinition): mixed
     {
-        if ($argumentDefinition instanceof DiDefinitionReference) {
+        if ($argumentDefinition instanceof DiDefinitionGet) {
             return $this->getContainer()->get($argumentDefinition->getDefinition());
         }
 

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -6,7 +6,11 @@ namespace Kaspi\DiContainer;
 
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
+
+// @todo Remove alias when remove function diReference.
+\class_alias(DiDefinitionGet::class, 'Kaspi\DiContainer\DiDefinition\DiDefinitionReference'); // @codeCoverageIgnore
 
 if (!\function_exists('Kaspi\DiContainer\diAutowire')) { // @codeCoverageIgnore
     // @phan-suppress-next-line PhanUnreferencedFunction
@@ -25,9 +29,27 @@ if (!\function_exists('Kaspi\DiContainer\diCallable')) { // @codeCoverageIgnore
 } // @codeCoverageIgnore
 
 if (!\function_exists('Kaspi\DiContainer\diReference')) { // @codeCoverageIgnore
-    // @phan-suppress-next-line PhanUnreferencedFunction
+    /**
+     * @deprecated Function diReference() was deprecated, used diGet()
+     *
+     * @phan-suppress PhanUnreferencedFunction
+     * @phan-suppress PhanUndeclaredClassMethod
+     * @phan-suppress PhanUndeclaredTypeReturnType
+     */
     function diReference(string $containerIdentifier): DiDefinitionReference
     {
+        @\trigger_error('Function diReference() was deprecated, used diGet(). This function will remove next realise.', \E_USER_DEPRECATED);
+
         return new DiDefinitionReference($containerIdentifier);
+    }
+} // @codeCoverageIgnore
+
+if (!\function_exists('Kaspi\DiContainer\diGet')) { // @codeCoverageIgnore
+    /**
+     * @phan-suppress PhanUnreferencedFunction
+     */
+    function diGet(string $containerIdentifier): DiDefinitionGet
+    {
+        return new DiDefinitionGet($containerIdentifier);
     }
 } // @codeCoverageIgnore

--- a/tests/DiContainer/ResolveByInterface/ResolveByInterfaceTest.php
+++ b/tests/DiContainer/ResolveByInterface/ResolveByInterfaceTest.php
@@ -17,7 +17,7 @@ use Tests\DiContainer\ResolveByInterface\Fixtures\SuperInterface;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diCallable;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\Attributes\Service
@@ -27,8 +27,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\CallableParserTrait
  * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait
@@ -57,7 +57,7 @@ class ResolveByInterfaceTest extends TestCase
         $def = [
             diAutowire(ServiceViaAttributeWithClassA::class),
             // ...
-            'services.class-a' => diReference(ServiceViaAttributeWithClassA::class),
+            'services.class-a' => diGet(ServiceViaAttributeWithClassA::class),
         ];
 
         $container = new DiContainer($def, config: $config);
@@ -74,9 +74,9 @@ class ResolveByInterfaceTest extends TestCase
         );
 
         $def = [
-            'services.class-b' => diReference('services.class-a'),
+            'services.class-b' => diGet('services.class-a'),
             // ...
-            'services.class-a' => diReference('services.class-b'),
+            'services.class-a' => diGet('services.class-b'),
         ];
 
         $container = new DiContainer($def, config: $config);
@@ -113,9 +113,9 @@ class ResolveByInterfaceTest extends TestCase
         $def = [
             'services.one' => diAutowire(ServiceViaAttributeWithClassA::class, true),
             // ...
-            'services.x' => diReference('services.one'),
+            'services.x' => diGet('services.one'),
             // ...
-            ServiceViaAttributeWithClassInterface::class => diReference('services.x'),
+            ServiceViaAttributeWithClassInterface::class => diGet('services.x'),
         ];
 
         $container = new DiContainer($def, config: $config);

--- a/tests/DiContainerCall/CallFunctionTest.php
+++ b/tests/DiContainerCall/CallFunctionTest.php
@@ -19,9 +19,9 @@ use function Kaspi\DiContainer\diAutowire;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait::getParameterTypeByReflection
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::isUseAttribute
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::setUseAttribute

--- a/tests/DiContainerCall/CircularReference/MainTest.php
+++ b/tests/DiContainerCall/CircularReference/MainTest.php
@@ -14,7 +14,7 @@ use Tests\DiContainerCall\CircularReference\Fixtures\SecondClass;
 use Tests\DiContainerCall\CircularReference\Fixtures\ThirdClass;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\Attributes\Inject
@@ -23,8 +23,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait::getParameterTypeByReflection
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::isUseAttribute
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::setUseAttribute
@@ -69,7 +69,7 @@ class MainTest extends TestCase
 
         $container->call(
             [ClassWithMethod::class, 'method'],
-            ['service' => diReference('services.second')]
+            ['service' => diGet('services.second')]
         );
     }
 

--- a/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
+++ b/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
@@ -13,7 +13,7 @@ use Tests\DiContainerCall\VariadicArg\Fixtures\WordSuffix;
 use Tests\DiContainerCall\VariadicArg\Fixtures\WordVariadicDiFactory;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\Attributes\Inject::getIdentifier
@@ -22,8 +22,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait::getParameterTypeByReflection
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::isUseAttribute
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::setUseAttribute
@@ -32,7 +32,7 @@ use function Kaspi\DiContainer\diReference;
  */
 class CallClassDefinitionVariadicArgTest extends TestCase
 {
-    public function testCallStaticMethodWithoutAttributePassArgumentByDiReference(): void
+    public function testCallStaticMethodWithoutAttributePassArgumentBydiGet(): void
     {
         $config = new DiContainerConfig(
             useZeroConfigurationDefinition: true,
@@ -44,8 +44,8 @@ class CallClassDefinitionVariadicArgTest extends TestCase
             [Talk::class, 'staticMethodByReference'],
             [
                 'word' => [ // <- variadic vars wrap by array
-                    diReference(WordSuffix::class),
-                    diReference(WordHello::class),
+                    diGet(WordSuffix::class),
+                    diGet(WordHello::class),
                 ], // <- variadic vars wrap by array
             ]
         );
@@ -88,7 +88,7 @@ class CallClassDefinitionVariadicArgTest extends TestCase
         $res = $container->call(
             [Talk::class, 'staticMethodByReference'],
             [
-                'word' => diReference('service.word'),
+                'word' => diGet('service.word'),
             ]
         );
         $this->assertInstanceOf(WordSuffix::class, $res[0]);

--- a/tests/DiContainerCall/VariadicArg/CallFunctionWithVariadicArgTest.php
+++ b/tests/DiContainerCall/VariadicArg/CallFunctionWithVariadicArgTest.php
@@ -14,7 +14,7 @@ use Tests\DiContainerCall\VariadicArg\Fixtures\WordSuffix;
 use Tests\DiContainerCall\VariadicArg\Fixtures\WordVariadicDiFactory;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\Attributes\Inject
@@ -23,8 +23,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::isUseAttribute
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait::setUseAttribute
  *
@@ -32,7 +32,7 @@ use function Kaspi\DiContainer\diReference;
  */
 class CallFunctionWithVariadicArgTest extends TestCase
 {
-    public function testUserFunctionVariadicArgumentsPassByCallMethodWithDiReference(): void
+    public function testUserFunctionVariadicArgumentsPassByCallMethodWithdiGet(): void
     {
         $fn = static fn (
             WordInterface ...$word
@@ -48,8 +48,8 @@ class CallFunctionWithVariadicArgTest extends TestCase
             $fn,
             [
                 'word' => [
-                    diReference('services.word_hello'),
-                    diReference('services.word_suffix'),
+                    diGet('services.word_hello'),
+                    diGet('services.word_suffix'),
                 ],
             ]
         );
@@ -107,7 +107,7 @@ class CallFunctionWithVariadicArgTest extends TestCase
         ];
         $container = new DiContainer($definitions, new DiContainerConfig());
 
-        $res = $container->call($fn, ['word' => diReference('services.words')]);
+        $res = $container->call($fn, ['word' => diGet('services.words')]);
 
         $this->assertInstanceOf(WordSuffix::class, $res[0]);
         $this->assertInstanceOf(WordHello::class, $res[1]);

--- a/tests/DiDefinition/DiDefinitionReference/DiDefinitionReferenceTest.php
+++ b/tests/DiDefinition/DiDefinitionReference/DiDefinitionReferenceTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\DiDefinition\DiDefinitionReference;
 
-use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
  *
  * @internal
  */
@@ -30,7 +30,7 @@ class DiDefinitionReferenceTest extends TestCase
         $this->expectException(DiDefinitionExceptionInterface::class);
         $this->expectExceptionMessage('must be a non-empty string');
 
-        new DiDefinitionReference($definition);
+        new DiDefinitionGet($definition);
     }
 
     public function dataProviderDefinitionSuccess(): \Generator
@@ -49,6 +49,6 @@ class DiDefinitionReferenceTest extends TestCase
      */
     public function testDiDefinitionReferenceSuccess(string $definition, string $expect): void
     {
-        $this->assertEquals($expect, (new DiDefinitionReference($definition))->getDefinition());
+        $this->assertEquals($expect, (new DiDefinitionGet($definition))->getDefinition());
     }
 }

--- a/tests/FromDocs/PhpDefinitions/DiReferenceTest.php
+++ b/tests/FromDocs/PhpDefinitions/DiReferenceTest.php
@@ -11,7 +11,7 @@ use Tests\FromDocs\PhpDefinitions\Fixtures\MyUsers;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diCallable;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\diAutowire
@@ -21,14 +21,14 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerFactory
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait
  *
  * @internal
  */
-class DiReferenceTest extends TestCase
+class diGetTest extends TestCase
 {
     public function dataProvider(): \Generator
     {
@@ -40,7 +40,7 @@ class DiReferenceTest extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testDiReference(string $envValue, string $expectFile): void
+    public function testdiGet(string $envValue, string $expectFile): void
     {
         \putenv('APP_TEST_FILE');
         \putenv('APP_TEST_FILE='.$envValue);
@@ -56,7 +56,7 @@ class DiReferenceTest extends TestCase
                 isSingleton: true
             ),
             diAutowire(\SplFileInfo::class)
-                ->addArgument('filename', diReference('services.env')), // ссылка на определение
+                ->addArgument('filename', diGet('services.env')), // ссылка на определение
         ];
 
         $container = (new DiContainerFactory())->make($definitions);
@@ -64,7 +64,7 @@ class DiReferenceTest extends TestCase
         $this->assertEquals($expectFile, $container->get(\SplFileInfo::class)->getFilename());
     }
 
-    public function testDiReferenceByClasses(): void
+    public function testdiGetByClasses(): void
     {
         $definitions = [
             'data' => ['user1', 'user2'],
@@ -73,12 +73,12 @@ class DiReferenceTest extends TestCase
 
             // внедрение зависимости аргумента по ссылке на контейнер-id
             diAutowire(MyUsers::class)
-                ->addArgument('users', diReference('data'))
+                ->addArgument('users', diGet('data'))
                 ->addArgument('type', 'Some value'),
             diAutowire(MyEmployers::class)
                 // добавить много аргументов за один раз
                 ->addArguments([
-                    'employers' => diReference('data'),
+                    'employers' => diGet('data'),
                     'type' => 'Other value',
                 ]),
         ];

--- a/tests/FromDocs/PhpDefinitions/ResolveByInterfaceTest.php
+++ b/tests/FromDocs/PhpDefinitions/ResolveByInterfaceTest.php
@@ -10,7 +10,7 @@ use Tests\FromDocs\PhpDefinitions\Fixtures\ClassFirst;
 use Tests\FromDocs\PhpDefinitions\Fixtures\ClassInterface;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\diAutowire
@@ -18,8 +18,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiContainerFactory
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait
  *
  * @internal
@@ -49,7 +49,7 @@ class ResolveByInterfaceTest extends TestCase
         // ... many definitions ...
 
         $interfacesDefinitions = [
-            ClassInterface::class => diReference(ClassFirst::class),
+            ClassInterface::class => diGet(ClassFirst::class),
         ];
 
         $container = (new DiContainerFactory())->make(

--- a/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
+++ b/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
@@ -12,7 +12,7 @@ use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleC;
 use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleGenerator;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\diAutowire
@@ -20,8 +20,8 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiContainerFactory
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait
  *
  * @internal
@@ -38,7 +38,7 @@ class VariadicArgumentTest extends TestCase
                     value: [ // <-- обернуть параметры в массив для variadic типов если их несколько.
                         diAutowire(RuleB::class),
                         diAutowire(RuleA::class),
-                        diReference('ruleC'), // <-- получение по ссылке
+                        diGet('ruleC'), // <-- получение по ссылке
                     ], // <-- обернуть параметры в массив если их несколько.
                 ),
         ];

--- a/tests/Function/HelperFunctionTest.php
+++ b/tests/Function/HelperFunctionTest.php
@@ -6,11 +6,13 @@ namespace Tests\Function;
 
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
 use PHPUnit\Framework\TestCase;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diCallable;
+use function Kaspi\DiContainer\diGet;
 use function Kaspi\DiContainer\diReference;
 
 /**
@@ -18,19 +20,20 @@ use function Kaspi\DiContainer\diReference;
  * @covers \Kaspi\DiContainer\diCallable
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionCallable
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\diReference
  *
  * @internal
  */
 class HelperFunctionTest extends TestCase
 {
-    public function testFunctionDiReference(): void
+    public function testFunctiondiGet(): void
     {
-        $def = diReference('ok');
+        $def = diGet('ok');
 
-        $this->assertInstanceOf(DiDefinitionReference::class, $def);
+        $this->assertInstanceOf(DiDefinitionGet::class, $def);
         $this->assertEquals('ok', $def->getDefinition());
     }
 
@@ -48,5 +51,13 @@ class HelperFunctionTest extends TestCase
 
         $this->assertInstanceOf(DiDefinitionAutowire::class, $def);
         $this->assertTrue($def->isSingleton());
+    }
+
+    public function testDepricatedFunctionDiReference(): void
+    {
+        $def = diReference('ok');
+
+        $this->assertInstanceOf(DiDefinitionReference::class, $def);
+        $this->assertEquals('ok', $def->getDefinition());
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
@@ -15,13 +15,13 @@ use Tests\Traits\ParametersResolver\Fixtures\SuperDiFactory;
 use Tests\Traits\ParametersResolver\Fixtures\SuperInterface;
 
 use function Kaspi\DiContainer\diAutowire;
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
  * @covers \Kaspi\DiContainer\diAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait
  * @covers \Kaspi\DiContainer\Traits\UseAttributeTrait
  *
@@ -129,7 +129,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         $this->assertInstanceOf(SuperClass::class, $res[1]);
     }
 
-    public function testResolveByAutowireDefinitionVariadicByDiReferenceAkaTag(): void
+    public function testResolveByAutowireDefinitionVariadicBydiGetAkaTag(): void
     {
         $fn = static fn (SuperInterface ...$item) => $item;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
@@ -147,7 +147,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
 
         // 🚩 test data
         $this->arguments = [
-            'item' => diReference('services.super'),
+            'item' => diGet('services.super'),
         ];
 
         $res = \call_user_func_array($fn, $this->resolveParameters());

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
@@ -9,24 +9,24 @@ use Kaspi\DiContainer\Traits\PsrContainerTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-use function Kaspi\DiContainer\diReference;
+use function Kaspi\DiContainer\diGet;
 
 /**
- * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionReference
- * @covers \Kaspi\DiContainer\diReference
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait
  * @covers \Kaspi\DiContainer\Traits\PsrContainerTrait
  *
  * @internal
  */
-class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
+class ParameterResolveByUserDefinedArgumentBydiGetTest extends TestCase
 {
     // 🔥 Test Trait 🔥
     use ParametersResolverTrait;
     // 🧨 need for abstract method getContainer.
     use PsrContainerTrait;
 
-    public function testUserDefinedArgumentByDiReferenceNonVariadicSuccess(): void
+    public function testUserDefinedArgumentBydiGetNonVariadicSuccess(): void
     {
         $fn = static fn (\ArrayIterator $iterator) => $iterator;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
@@ -39,7 +39,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->setContainer($mockContainer);
         // 🚩 test data
         $this->arguments = [
-            'iterator' => diReference('services.icon-iterator'),
+            'iterator' => diGet('services.icon-iterator'),
         ];
 
         $res = \call_user_func_array($fn, $this->resolveParameters());
@@ -48,7 +48,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->assertEquals(['🚀', '🔥'], $res->getArrayCopy());
     }
 
-    public function testUserDefinedArgumentByManyDiReferenceVariadic(): void
+    public function testUserDefinedArgumentByManydiGetVariadic(): void
     {
         $fn = static fn (\ArrayIterator ...$iterator) => $iterator;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
@@ -70,8 +70,8 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         // 🚩 test data
         $this->arguments = [
             'iterator' => [
-                diReference('services.icon-iterator.two'),
-                diReference('services.icon-iterator.one'),
+                diGet('services.icon-iterator.two'),
+                diGet('services.icon-iterator.one'),
             ],
         ];
 
@@ -86,7 +86,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->assertEquals(['🔥'], $res[1]->getArrayCopy());
     }
 
-    public function testUserDefinedArgumentByOneDiReferenceVariadic(): void
+    public function testUserDefinedArgumentByOnediGetVariadic(): void
     {
         $fn = static fn (\ArrayIterator ...$iterator) => $iterator;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
@@ -106,7 +106,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->setContainer($mockContainer);
         // 🚩 test data
         $this->arguments = [
-            'iterator' => diReference('services.icon-iterator'),
+            'iterator' => diGet('services.icon-iterator'),
         ];
 
         $res = \call_user_func_array($fn, $this->resolveParameters());


### PR DESCRIPTION
- Rename class DiDefinitionReference to DiDefinitionGet.
- Rename also function diReference to diGet.
- Function diReference deprecate.