### PR TITLE
Variadic arguments by bindArguments

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -512,7 +512,8 @@ $container->get('doSomething'); // (object) ['name' => 'John Doe', 'age' => 32, 
 
 ## Разрешение аргументов переменной длины
 
-Каждое определение для `variadic` аргумента необходимо объявлять как массив `[]` если нужно разрешить несколько зависимостей.
+Каждый аргумент для `variadic` параметра необходимо объявлять
+как массив `[]` если используется передача по имени.
 
 ```php
 // Объявления классов
@@ -545,12 +546,13 @@ $definition = [
     'ruleC' => diAutowire(App\Rules\RuleC::class),
     diAutowire(App\Rules\RuleGenerator::class)
         ->bindArguments(
-            // имя аргумента в конструкторе
-            inputRule: [ // <-- обернуть параметры в массив для variadic типов если их несколько.
-                diAutowire(App\Rules\RuleB::class),
-                diAutowire(App\Rules\RuleA::class),
-                diGet('ruleC'), // <-- получение по ссылке
-            ], // <-- обернуть параметры в массив если их несколько.            
+            // имя параметра $inputRule в конструкторе
+            inputRule:
+                [ // <-- обернуть параметры в массив для variadic типов если их несколько.
+                    diAutowire(App\Rules\RuleB::class),
+                    diAutowire(App\Rules\RuleA::class),
+                    diGet('ruleC'), // <-- получение по ссылке
+                ], // <-- обернуть параметры в массив если их несколько.            
         )
 ];
 
@@ -563,19 +565,17 @@ assert($ruleGenerator->getRules()[0] instanceof App\Rules\RuleB); // true
 assert($ruleGenerator->getRules()[1] instanceof App\Rules\RuleA); // true
 assert($ruleGenerator->getRules()[2] instanceof App\Rules\RuleС); // true
 ```
-> ⛏ Можно не указывать имя аргумента для метода `bindArguments`, тогда определение будет выглядеть так:
->```php
-> // Передать три аргумента в конструктор класс
-> diAutowire(App\Rules\RuleGenerator::class)
->   // Передать в параметр с индексом 0 значение.
->   ->bindArguments(
->       [ // <-- обернуть параметры в массив для variadic типов если их несколько.
->           diAutowire(App\Rules\RuleB::class),
->           diAutowire(App\Rules\RuleA::class),
->           diGet('ruleC'), // <-- получение по ссылке
->       ] // <-- обернуть параметры в массив если их несколько.
->   );
-> ```
+⛏ Если не использовать имя параметра то передавать аргументы по индексу в конструкторе можно просто перечисляя нужные определения:
+```php
+ // Передать три аргумента в конструктор класс
+ diAutowire(App\Rules\RuleGenerator::class)
+   // Передать в параметр с индексом 0 значение.
+   ->bindArguments(
+       diAutowire(App\Rules\RuleB::class),
+       diAutowire(App\Rules\RuleA::class),
+       diGet('ruleC'), // <-- получение по ссылке
+   );
+```
 
 ## Примеры использования для конфигурирования:
 

--- a/src/DiContainer/Traits/ParametersResolverTrait.php
+++ b/src/DiContainer/Traits/ParametersResolverTrait.php
@@ -275,8 +275,25 @@ trait ParametersResolverTrait
             return $this->arguments[$parameter->name];
         }
 
-        if (\array_key_exists($parameter->getPosition(), $this->arguments)) {
+        if (!$parameter->isVariadic() && \array_key_exists($parameter->getPosition(), $this->arguments)) {
             return $this->arguments[$parameter->getPosition()];
+        }
+
+        if ($parameter->isVariadic() && \array_key_exists($parameter->getPosition(), $this->arguments)) {
+            $variadicPosition = $parameter->getPosition();
+
+            if (!\array_key_exists($variadicPosition + 1, $this->arguments)) {
+                return $this->arguments[$variadicPosition];
+            }
+
+            $values = [];
+
+            do {
+                $values[] = $this->arguments[$variadicPosition];
+                ++$variadicPosition;
+            } while (\array_key_exists($variadicPosition, $this->arguments));
+
+            return $values;
         }
 
         throw new InputArgumentNotFoundException();

--- a/src/DiContainer/Traits/ParametersResolverTrait.php
+++ b/src/DiContainer/Traits/ParametersResolverTrait.php
@@ -101,14 +101,13 @@ trait ParametersResolverTrait
         $this->validateInputArguments();
 
         $dependencies = [];
+        self::$variadicPosition = 0;
 
         foreach ($this->reflectionParameters as $parameter) {
             try {
                 $argumentDefinition = $this->getInputArgument($parameter);
 
                 if (\is_array($argumentDefinition) && $parameter->isVariadic()) {
-                    self::$variadicPosition = 0;
-
                     foreach ($argumentDefinition as $definitionItem) {
                         $resolvedVal = $this->resolveInputArgument($parameter, $definitionItem);
                         $dependencies[] = $resolvedVal;
@@ -134,8 +133,6 @@ trait ParametersResolverTrait
             try {
                 if ($this->isUseAttribute() && ($injectAttribute = $this->getInjectAttribute($parameter))
                     && $injectAttribute->valid()) {
-                    self::$variadicPosition = 0;
-
                     foreach ($injectAttribute as $inject) {
                         $resolvedVal = $inject->getIdentifier()
                             ? $this->getContainer()->get($inject->getIdentifier())

--- a/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
+++ b/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
@@ -28,7 +28,7 @@ use function Kaspi\DiContainer\diGet;
  */
 class VariadicArgumentTest extends TestCase
 {
-    public function testVariadicArgument(): void
+    public function testVariadicArgumentByName(): void
     {
         $definition = [
             'ruleC' => diAutowire(RuleC::class),
@@ -47,6 +47,28 @@ class VariadicArgumentTest extends TestCase
 
         $ruleGenerator = $container->get(RuleGenerator::class);
 
+        $this->assertInstanceOf(RuleB::class, $ruleGenerator->getRules()[0]);
+        $this->assertInstanceOf(RuleA::class, $ruleGenerator->getRules()[1]);
+        $this->assertInstanceOf(RuleC::class, $ruleGenerator->getRules()[2]);
+    }
+
+    public function testVariadicArgumentByIndex(): void
+    {
+        $definition = [
+            'ruleC' => diAutowire(RuleC::class),
+            diAutowire(RuleGenerator::class)
+                ->bindArguments(
+                    diAutowire(RuleB::class),
+                    diAutowire(RuleA::class),
+                    diGet('ruleC'), // <-- получение по ссылке
+                ),
+        ];
+
+        $container = (new DiContainerFactory())->make($definition);
+
+        $ruleGenerator = $container->get(RuleGenerator::class);
+
+        $this->assertCount(3, $ruleGenerator->getRules());
         $this->assertInstanceOf(RuleB::class, $ruleGenerator->getRules()[0]);
         $this->assertInstanceOf(RuleA::class, $ruleGenerator->getRules()[1]);
         $this->assertInstanceOf(RuleC::class, $ruleGenerator->getRules()[2]);

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
@@ -94,9 +94,9 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $mockContainer = $this->createMock(ContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with($this->logicalOr(
-                'services.icon-iterator.one',
-                'services.icon-iterator.two'
+            ->with(self::logicalOr(
+                'services.icon-iterator.two',
+                'services.icon-iterator.one'
             ))
             ->willReturn(
                 new \ArrayIterator(array: ['🚀']),

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
@@ -48,13 +48,13 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->assertEquals(['🚀', '🔥'], $res->getArrayCopy());
     }
 
-    public function testUserDefinedArgumentByManydiGetVariadic(): void
+    public function testUserDefinedArgumentByManydiGetVariadicByName(): void
     {
         $fn = static fn (\ArrayIterator ...$iterator) => $iterator;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
 
         $mockContainer = $this->createMock(ContainerInterface::class);
-        $mockContainer->expects($this->atMost(2))
+        $mockContainer->expects(self::exactly(2))
             ->method('get')
             ->with($this->logicalOr(
                 'services.icon-iterator.one',
@@ -86,13 +86,49 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->assertEquals(['🔥'], $res[1]->getArrayCopy());
     }
 
+    public function testUserDefinedArgumentByManydiGetVariadicByIndex(): void
+    {
+        $fn = static fn (\ArrayIterator ...$iterator) => $iterator;
+        $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
+
+        $mockContainer = $this->createMock(ContainerInterface::class);
+        $mockContainer->expects(self::exactly(2))
+            ->method('get')
+            ->with($this->logicalOr(
+                'services.icon-iterator.one',
+                'services.icon-iterator.two'
+            ))
+            ->willReturn(
+                new \ArrayIterator(array: ['🚀']),
+                new \ArrayIterator(array: ['🔥']),
+            )
+        ;
+
+        $this->setContainer($mockContainer);
+        // 🚩 test data
+        $this->bindArguments(
+            diGet('services.icon-iterator.two'),
+            diGet('services.icon-iterator.one'),
+        );
+
+        $res = \call_user_func_array($fn, $this->resolveParameters());
+
+        $this->assertCount(2, $res);
+
+        $this->assertInstanceOf(\ArrayIterator::class, $res[0]);
+        $this->assertEquals(['🚀'], $res[0]->getArrayCopy());
+
+        $this->assertInstanceOf(\ArrayIterator::class, $res[1]);
+        $this->assertEquals(['🔥'], $res[1]->getArrayCopy());
+    }
+
     public function testUserDefinedArgumentByOnediGetVariadicByIndex(): void
     {
         $fn = static fn (\ArrayIterator ...$iterator) => $iterator;
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
 
         $mockContainer = $this->createMock(ContainerInterface::class);
-        $mockContainer->expects($this->atMost(2))
+        $mockContainer->expects(self::once())
             ->method('get')
             ->with('services.icon-iterator')
             ->willReturn(

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
@@ -62,25 +62,26 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
 
     public function testUserDefinedArgumentAsArrayVariadicByIndexSuccess(): void
     {
-        $fn = static fn (iterable ...$iterator) => $iterator;
+        $fn = static fn (string $val, iterable ...$iterator) => [$val, $iterator];
         $this->reflectionParameters = (new \ReflectionFunction($fn))->getParameters();
 
         $mockContainer = $this->createMock(ContainerInterface::class);
-        $mockContainer->expects($this->never())->method('get');
+        $mockContainer->expects(self::never())->method('get');
         $this->setContainer($mockContainer);
 
         // 🚩 test data
-        $this->bindArguments([
+        $this->bindArguments(
+            'my way',
             ['aaa', 'bbb', 'ccc'],
             ['ddd', 'eee', 'fff'],
-        ]);
+        );
 
-        $res = \call_user_func_array($fn, $this->resolveParameters());
+        [$str ,$iter] = \call_user_func_array($fn, $this->resolveParameters());
 
-        $this->assertCount(2, $res);
-
-        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res[0]);
-        $this->assertEquals(['ddd', 'eee', 'fff'], $res[1]);
+        $this->assertEquals('my way', $str);
+        $this->assertCount(2, $iter);
+        $this->assertEquals(['aaa', 'bbb', 'ccc'], $iter[0]);
+        $this->assertEquals(['ddd', 'eee', 'fff'], $iter[1]);
     }
 
     public function testUserDefinedArgumentAsArrayVariadicByNameSuccess(): void
@@ -136,7 +137,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         $mockContainer->expects($this->never())->method('get');
         $this->setContainer($mockContainer);
 
-        // 🚩 test data
+        // 🚩 test data, unsorted parameter names
         $this->bindArguments(word: ['aaa', 'bbb', 'ccc'], numbers: [1_000, 10_000]);
 
         [$numbers, $word] = \call_user_func_array($fn, $this->resolveParameters());


### PR DESCRIPTION
Привязка аргументов для параметров переменной длинны без "оборачивания в массив", просто добавляя нужные значения в аргументы последовательно.
Например так:

```php
interface RuleInterface {}
class RuleA implements RuleInterface {}
class RuleB implements RuleInterface {}

class RuleGenerator {
    private iterable $rules;

    public function __construct(RuleInterface ...$inputRule) {
        $this->rules = $inputRule;
    }
   // ...
}


$definitions = [
    diAutowire(RuleGenerator::class)
        // add inline variadic argument
        ->bingArguments(diAutowire(RuleA::class), diAutowire(RuleB::class))
];

```