### PR TITLE
refactor/132-tagged-by-fqcn-part2

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -94,7 +94,7 @@ $container->get('feedback.email'); // array('help@my-company.inc', 'boss@my-comp
 Автоматическое создание объекта и внедрения зависимостей.
 
 ```php
-use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupInterface;
+use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionConfigAutowireInterface;
 use function \Kaspi\DiContainer\diAutowire;
 
 diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionSetupInterface

--- a/src/DiContainer/Attributes/Tag.php
+++ b/src/DiContainer/Attributes/Tag.php
@@ -13,7 +13,7 @@ final class Tag implements DiAttributeInterface
     /**
      * @param non-empty-string $name tag name
      */
-    public function __construct(private string $name, private array $options = [], private null|int|string $priority = null, private ?string $priorityTagMethod = null)
+    public function __construct(private string $name, private array $options = [], private null|int|string $priority = null, private ?string $priorityMethod = null)
     {
         if ('' === \trim($name)) {
             throw new AutowireAttributeException('The $name parameter must be a non-empty string.');
@@ -35,8 +35,8 @@ final class Tag implements DiAttributeInterface
         return $this->priority;
     }
 
-    public function getPriorityTagMethod(): ?string
+    public function getPriorityMethod(): ?string
     {
-        return $this->priorityTagMethod;
+        return $this->priorityMethod;
     }
 }

--- a/src/DiContainer/Attributes/TaggedAs.php
+++ b/src/DiContainer/Attributes/TaggedAs.php
@@ -17,16 +17,16 @@ final class TaggedAs implements DiAttributeInterface
         private string $name,
         private bool $isLazy = true,
         private ?string $defaultPriorityMethod = null,
-        private bool $requireDefaultPriorityMethod = false
+        private bool $defaultPriorityMethodIsRequired = false
     ) {
         if ('' === \trim($name)) {
             throw new AutowireAttributeException('The $name parameter must be a non-empty string.');
         }
     }
 
-    public function isRequireDefaultPriorityMethod(): bool
+    public function isDefaultPriorityMethodIsRequired(): bool
     {
-        return $this->requireDefaultPriorityMethod;
+        return $this->defaultPriorityMethodIsRequired;
     }
 
     public function getIdentifier(): string

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -161,9 +161,9 @@ final class DiDefinitionAutowire implements DiDefinitionConfigAutowireInterface,
 
         if (null !== $defaultPriorityMethod) {
             $howGetPriority = \sprintf('Get priority by option "defaultPriorityMethod" for class "%s".', $this->getDefinition()->getName());
-            $requireDefaultPriorityMethod = (bool) ($operationOptions['requireDefaultPriorityMethod'] ?? null);
+            $defaultPriorityMethodIsRequired = (bool) ($operationOptions['defaultPriorityMethodIsRequired'] ?? null);
 
-            return $this->invokePriorityMethod($defaultPriorityMethod, $requireDefaultPriorityMethod, $name, $howGetPriority);
+            return $this->invokePriorityMethod($defaultPriorityMethod, $defaultPriorityMethodIsRequired, $name, $howGetPriority);
         }
 
         return null;

--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -113,7 +113,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                 if ($definition instanceof DiTaggedDefinitionAutowireInterface) {
                     $operationOptions = tagOptions(
                         defaultPriorityMethod: $this->defaultPriorityMethod,
-                        requireDefaultPriorityMethod: $this->requireDefaultPriorityMethod
+                        defaultPriorityMethodIsRequired: $this->requireDefaultPriorityMethod
                     );
                 }
 
@@ -149,7 +149,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                             $this->tag,
                             tagOptions(
                                 defaultPriorityMethod: $this->defaultPriorityMethod,
-                                requireDefaultPriorityMethod: $this->requireDefaultPriorityMethod
+                                defaultPriorityMethodIsRequired: $this->requireDefaultPriorityMethod
                             )
                         )
                     );

--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -33,7 +33,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
         private string $tag,
         private bool $isLazy = true,
         private ?string $defaultPriorityMethod = null,
-        private bool $requireDefaultPriorityMethod = false
+        private bool $defaultPriorityMethodIsRequired = false
     ) {}
 
     /**
@@ -113,7 +113,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                 if ($definition instanceof DiTaggedDefinitionAutowireInterface) {
                     $operationOptions = tagOptions(
                         defaultPriorityMethod: $this->defaultPriorityMethod,
-                        defaultPriorityMethodIsRequired: $this->requireDefaultPriorityMethod
+                        defaultPriorityMethodIsRequired: $this->defaultPriorityMethodIsRequired
                     );
                 }
 
@@ -149,7 +149,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                             $this->tag,
                             tagOptions(
                                 defaultPriorityMethod: $this->defaultPriorityMethod,
-                                defaultPriorityMethodIsRequired: $this->requireDefaultPriorityMethod
+                                defaultPriorityMethodIsRequired: $this->defaultPriorityMethodIsRequired
                             )
                         )
                     );

--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -17,6 +17,8 @@ use Kaspi\DiContainer\Traits\DiContainerTrait;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
+use function Kaspi\DiContainer\tagOptions;
+
 final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDefinitionNoArgumentsInterface
 {
     use DiContainerTrait;
@@ -106,18 +108,17 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
             }
 
             if ($definition->hasTag($this->tag)) {
-                // 🚩 Tag with higher priority early in list.
+                $operationOptions = [];
+
                 if ($definition instanceof DiTaggedDefinitionAutowireInterface) {
-                    $taggedServices->insert(
-                        $containerIdentifier,
-                        $definition->geTagPriority($this->tag, $this->defaultPriorityMethod, $this->requireDefaultPriorityMethod)
-                    );
-                } else {
-                    $taggedServices->insert(
-                        $containerIdentifier,
-                        $definition->geTagPriority($this->tag)
+                    $operationOptions = tagOptions(
+                        defaultPriorityMethod: $this->defaultPriorityMethod,
+                        requireDefaultPriorityMethod: $this->requireDefaultPriorityMethod
                     );
                 }
+
+                // 🚩 Tag with higher priority early in list.
+                $taggedServices->insert($containerIdentifier, $definition->geTagPriority($this->tag, $operationOptions));
             }
         }
 
@@ -142,7 +143,16 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                     && $definition->getDefinition()->implementsInterface($this->tag)) { // @phan-suppress-current-line PhanPossiblyNonClassMethodCall
                     $definition->setContainer($this->getContainer());
                     // 🚩 Tag with higher priority early in list.
-                    $taggedServices->insert($containerIdentifier, $definition->geTagPriority($this->tag, $this->defaultPriorityMethod, $this->requireDefaultPriorityMethod));
+                    $taggedServices->insert(
+                        $containerIdentifier,
+                        $definition->geTagPriority(
+                            $this->tag,
+                            tagOptions(
+                                defaultPriorityMethod: $this->defaultPriorityMethod,
+                                requireDefaultPriorityMethod: $this->requireDefaultPriorityMethod
+                            )
+                        )
+                    );
                 }
             } catch (AutowireExceptionInterface $e) {
                 throw new ContainerException(message: $e->getMessage(), previous: $e);

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 
-interface DiDefinitionSetupInterface extends DiDefinitionArgumentsInterface
+interface DiDefinitionConfigAutowireInterface extends DiDefinitionArgumentsInterface
 {
     /**
      * Call setter method for class with input arguments.
@@ -28,16 +28,4 @@ interface DiDefinitionSetupInterface extends DiDefinitionArgumentsInterface
      * @return $this
      */
     public function setup(string $method, mixed ...$argument): static;
-
-    /**
-     * Bind tag for services with meta-data.
-     *
-     * @param non-empty-string               $name              tag name
-     * @param array<non-empty-string, mixed> $options           tag's meta-data
-     * @param null|int|string                $priority          priority for sorting tag collection
-     * @param null|string                    $priorityTagMethod method return priority value for tag $name
-     *
-     * @return $this
-     */
-    public function bindTag(string $name, array $options, null|int|string $priority, ?string $priorityTagMethod = null): static;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionTagArgumentInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionTagArgumentInterface.php
@@ -12,6 +12,8 @@ interface DiDefinitionTagArgumentInterface
      * @param non-empty-string               $name     tag name
      * @param array<non-empty-string, mixed> $options  tag's meta-data
      * @param null|int|string                $priority priority for sorting tag collection
+     *
+     * @return $this
      */
-    public function bindTag(string $name, array $options, null|int|string $priority): static;
+    public function bindTag(string $name, array $options = [], null|int|string $priority = null): static;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionAutowireInterface.php
@@ -10,15 +10,6 @@ use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 interface DiTaggedDefinitionAutowireInterface extends DiTaggedDefinitionInterface
 {
     /**
-     * Get priority for tag with extended parameters for php classes.
-     *
-     * @param non-empty-string $name
-     * @param null|string      $defaultPriorityTagMethod     method return priority if not defined priority in tag option
-     * @param bool             $requireDefaultPriorityMethod method for get priority is required
-     */
-    public function geTagPriority(string $name, ?string $defaultPriorityTagMethod = null, bool $requireDefaultPriorityMethod = false): null|int|string;
-
-    /**
      * @throws AutowireExceptionInterface
      */
     public function getDefinition(): \ReflectionClass;

--- a/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionInterface.php
@@ -32,11 +32,13 @@ interface DiTaggedDefinitionInterface
     /**
      * Get priority for tag.
      *
-     * @param non-empty-string $name
+     * @param non-empty-string               $name
+     * @param array<non-empty-string, mixed> $operationOptions temporary options (meta-data) for operation
      */
     public function geTagPriority(string $name, array $operationOptions = []): null|int|string;
 
     /**
+     * @param non-empty-string               $name
      * @param array<non-empty-string, mixed> $options
      *
      * @return $this

--- a/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiTaggedDefinitionInterface.php
@@ -34,5 +34,12 @@ interface DiTaggedDefinitionInterface
      *
      * @param non-empty-string $name
      */
-    public function geTagPriority(string $name): null|int|string;
+    public function geTagPriority(string $name, array $operationOptions = []): null|int|string;
+
+    /**
+     * @param array<non-empty-string, mixed> $options
+     *
+     * @return $this
+     */
+    public function bindTag(string $name, array $options = [], null|int|string $priority = null): static;
 }

--- a/src/DiContainer/Traits/ParametersResolverTrait.php
+++ b/src/DiContainer/Traits/ParametersResolverTrait.php
@@ -239,7 +239,7 @@ trait ParametersResolverTrait
                         $tagged->getIdentifier(),
                         $tagged->isLazy(),
                         $tagged->getDefaultPriorityMethod(),
-                        $tagged->isRequireDefaultPriorityMethod()
+                        $tagged->isDefaultPriorityMethodIsRequired()
                     )
                 );
             }

--- a/src/DiContainer/Traits/TagsTrait.php
+++ b/src/DiContainer/Traits/TagsTrait.php
@@ -45,9 +45,9 @@ trait TagsTrait
         return [] !== $this->tags && isset($this->tags[$name]);
     }
 
-    public function geTagPriority(string $name): null|int|string
+    public function geTagPriority(string $name, array $operationOptions = []): null|int|string
     {
-        $options = $this->getTag($name);
+        $options = ($this->getTag($name) ?? []) + $operationOptions;
 
         return $options && \array_key_exists('priority', $options) && (\is_int($priority = $options['priority']) || \is_string($priority))
             ? $priority

--- a/src/DiContainer/Traits/TagsTrait.php
+++ b/src/DiContainer/Traits/TagsTrait.php
@@ -47,7 +47,7 @@ trait TagsTrait
 
     public function geTagPriority(string $name, array $operationOptions = []): null|int|string
     {
-        $options = ($this->getTag($name) ?? []) + $operationOptions;
+        $options = $operationOptions + ($this->getTag($name) ?? []);
 
         return $options && \array_key_exists('priority', $options) && (\is_int($priority = $options['priority']) || \is_string($priority))
             ? $priority

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -102,11 +102,11 @@ if (!\function_exists('Kaspi\DiContainer\tagOptions')) {
     function tagOptions(
         ?string $priorityMethod = null,
         ?string $defaultPriorityMethod = null,
-        ?bool $requireDefaultPriorityMethod = null,
+        ?bool $defaultPriorityMethodIsRequired = null,
     ): array {
         return
             (null !== $priorityMethod ? ['priorityMethod' => $priorityMethod] : [])
             + (null !== $defaultPriorityMethod ? ['defaultPriorityMethod' => $defaultPriorityMethod] : [])
-            + (null !== $defaultPriorityMethod && null !== $requireDefaultPriorityMethod ? ['requireDefaultPriorityMethod' => $requireDefaultPriorityMethod] : []);
+            + (null !== $defaultPriorityMethod && null !== $defaultPriorityMethodIsRequired ? ['defaultPriorityMethodIsRequired' => $defaultPriorityMethodIsRequired] : []);
     }
 }

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -104,8 +104,7 @@ if (!\function_exists('Kaspi\DiContainer\tagOptions')) { // @codeCoverageIgnore
         ?string $defaultPriorityMethod = null,
         ?bool $defaultPriorityMethodIsRequired = null,
     ): array {
-        return
-            (null !== $priorityMethod ? ['priorityMethod' => $priorityMethod] : [])
+        return (null !== $priorityMethod ? ['priorityMethod' => $priorityMethod] : [])
             + (null !== $defaultPriorityMethod ? ['defaultPriorityMethod' => $defaultPriorityMethod] : [])
             + (null !== $defaultPriorityMethod && null !== $defaultPriorityMethodIsRequired ? ['defaultPriorityMethodIsRequired' => $defaultPriorityMethodIsRequired] : []);
     }

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -12,9 +12,9 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionReference;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionConfigAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 
 // @todo Remove alias when remove function diReference.
@@ -26,7 +26,7 @@ if (!\function_exists('Kaspi\DiContainer\diAutowire')) { // @codeCoverageIgnore
      *
      * @param class-string $definition
      */
-    function diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionSetupInterface
+    function diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionConfigAutowireInterface
     {
         return new DiDefinitionAutowire($definition, $isSingleton);
     }
@@ -97,3 +97,16 @@ if (!\function_exists('Kaspi\DiContainer\diTaggedAs')) { // @codeCoverageIgnore
         return new DiDefinitionTaggedAs($tag, $isLazy, $defaultPriorityMethod, $requireDefaultPriorityMethod);
     }
 } // @codeCoverageIgnore
+
+if (!\function_exists('Kaspi\DiContainer\tagOptions')) {
+    function tagOptions(
+        ?string $priorityMethod = null,
+        ?string $defaultPriorityMethod = null,
+        ?bool $requireDefaultPriorityMethod = null,
+    ): array {
+        return
+            (null !== $priorityMethod ? ['priorityMethod' => $priorityMethod] : [])
+            + (null !== $defaultPriorityMethod ? ['defaultPriorityMethod' => $defaultPriorityMethod] : [])
+            + (null !== $defaultPriorityMethod && null !== $requireDefaultPriorityMethod ? ['requireDefaultPriorityMethod' => $requireDefaultPriorityMethod] : []);
+    }
+}

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -98,7 +98,7 @@ if (!\function_exists('Kaspi\DiContainer\diTaggedAs')) { // @codeCoverageIgnore
     }
 } // @codeCoverageIgnore
 
-if (!\function_exists('Kaspi\DiContainer\tagOptions')) {
+if (!\function_exists('Kaspi\DiContainer\tagOptions')) { // @codeCoverageIgnore
     function tagOptions(
         ?string $priorityMethod = null,
         ?string $defaultPriorityMethod = null,
@@ -109,4 +109,4 @@ if (!\function_exists('Kaspi\DiContainer\tagOptions')) {
             + (null !== $defaultPriorityMethod ? ['defaultPriorityMethod' => $defaultPriorityMethod] : [])
             + (null !== $defaultPriorityMethod && null !== $defaultPriorityMethodIsRequired ? ['defaultPriorityMethodIsRequired' => $defaultPriorityMethodIsRequired] : []);
     }
-}
+} // @codeCoverageIgnore

--- a/tests/Attributes/Raw/TagTest.php
+++ b/tests/Attributes/Raw/TagTest.php
@@ -40,7 +40,7 @@ class TagTest extends TestCase
         $this->assertEquals('tags.handler-one', $tag->getIdentifier());
         $this->assertEquals([], $tag->getOptions());
         $this->assertNull($tag->getPriority());
-        $this->assertNull($tag->getPriorityTagMethod());
+        $this->assertNull($tag->getPriorityMethod());
     }
 
     public function testTagOptionsNotOverrideSomeOptions(): void
@@ -49,6 +49,6 @@ class TagTest extends TestCase
 
         $this->assertEquals(['priority' => 100, 'meta-data' => ['foo' => 'bar']], $tag->getOptions());
         $this->assertEquals(50, $tag->getPriority());
-        $this->assertEquals('getPriorityTag', $tag->getPriorityTagMethod());
+        $this->assertEquals('getPriorityTag', $tag->getPriorityMethod());
     }
 }

--- a/tests/DiContainerCall/CircularReference/MainTest.php
+++ b/tests/DiContainerCall/CircularReference/MainTest.php
@@ -28,6 +28,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait::getParameterTypeByReflection
  *
  * @internal

--- a/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
@@ -13,10 +13,13 @@ use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagOne;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagTwo;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagTwoDefault;
 
+use function Kaspi\DiContainer\tagOptions;
+
 /**
  * @covers \Kaspi\DiContainer\Attributes\Tag
  * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
+ * @covers \Kaspi\DiContainer\tagOptions
  *
  * @internal
  */
@@ -26,7 +29,7 @@ class TagTest extends TestCase
     {
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $def = (new DiDefinitionAutowire(TaggedClassBindTagOne::class))
-            ->bindTag('tags.handler-one', priorityTagMethod: 'getTaggedPriority')
+            ->bindTag('tags.handler-one', tagOptions(priorityMethod: 'getTaggedPriority'))
             ->bindTag('tags.handler-two', ['exclude.compile' => true], priority: 1000)
             ->bindTag('tags.handler-three')
             ->setContainer($mockContainer)
@@ -34,7 +37,7 @@ class TagTest extends TestCase
 
         $this->assertEquals(
             [
-                'tags.handler-one' => ['priorityTagMethod' => 'getTaggedPriority'],
+                'tags.handler-one' => ['priorityMethod' => 'getTaggedPriority'],
                 'tags.handler-two' => ['priority' => 1000, 'exclude.compile' => true],
                 'tags.handler-three' => [],
             ],
@@ -42,14 +45,14 @@ class TagTest extends TestCase
         );
 
         $this->assertTrue($def->hasTag('tags.handler-one'));
-        $this->assertEquals(['priorityTagMethod' => 'getTaggedPriority'], $def->getTag('tags.handler-one'));
+        $this->assertEquals(['priorityMethod' => 'getTaggedPriority'], $def->getTag('tags.handler-one'));
         $this->assertEquals(1000, $def->geTagPriority('tags.handler-one'));
 
         $this->assertTrue($def->hasTag('tags.handler-two'));
         $this->assertEquals(['priority' => 1000, 'exclude.compile' => true], $def->getTag('tags.handler-two'));
         $this->assertEquals(1000, $def->geTagPriority('tags.handler-two'));
 
-        $this->assertEquals(1000, $def->geTagPriority('tags.handler-three', defaultPriorityTagMethod: 'getTaggedPriority'));
+        $this->assertEquals(1000, $def->geTagPriority('tags.handler-three', ['defaultPriorityMethod' => 'getTaggedPriority']));
     }
 
     public function testTagsByPhpAttribute(): void
@@ -151,7 +154,7 @@ class TagTest extends TestCase
     {
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $def = (new DiDefinitionAutowire(TaggedClassBindTagOne::class))
-            ->bindTag('tags.handler-one', priorityTagMethod: $priorityTagMethod)
+            ->bindTag('tags.handler-one', tagOptions(priorityMethod: $priorityTagMethod))
             ->setContainer($mockContainer)
         ;
 
@@ -163,15 +166,15 @@ class TagTest extends TestCase
 
     public static function dataProviderPriorityTagMethodByOptionsWrongType(): \Generator
     {
-        yield 'empty string' => [['priorityTagMethod' => '']];
+        yield 'empty string' => [tagOptions(priorityMethod: '')];
 
-        yield 'string with sapces' => [['priorityTagMethod' => '  ']];
+        yield 'string with sapces' => [tagOptions(priorityMethod: '   ')];
 
-        yield 'array' => [['priorityTagMethod' => ['method']]];
+        yield 'array' => [['priorityMethod' => ['method']]];
 
-        yield 'boolean' => [['priorityTagMethod' => true]];
+        yield 'boolean' => [['priorityMethod' => true]];
 
-        yield 'stdClass' => [['priorityTagMethod' => new \stdClass()]];
+        yield 'stdClass' => [['priorityMethod' => new \stdClass()]];
     }
 
     /**
@@ -199,7 +202,7 @@ class TagTest extends TestCase
             ->setContainer($mockContainer)
         ;
 
-        $this->assertEquals(1000, $def->geTagPriority('tags.handler-one', defaultPriorityTagMethod: 'getTaggedPriority'));
+        $this->assertEquals(1000, $def->geTagPriority('tags.handler-one', tagOptions(defaultPriorityMethod: 'getTaggedPriority')));
     }
 
     public function testGetPriorityByDefaultPriorityTagMethodFailIsRequiredFalse(): void
@@ -210,7 +213,7 @@ class TagTest extends TestCase
             ->setContainer($mockContainer)
         ;
 
-        $this->assertNull($def->geTagPriority('tags.handler-one', defaultPriorityTagMethod: 'getTaggedPriorityNonExist'));
+        $this->assertNull($def->geTagPriority('tags.handler-one', tagOptions(defaultPriorityMethod: 'getTaggedPriorityNonExist')));
     }
 
     public function testGetPriorityByDefaultPriorityTagMethodFailIsRequiredTrue(): void
@@ -224,7 +227,7 @@ class TagTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessage('method must be declared with public and static modifiers. Return type must be int, string, null');
 
-        $def->geTagPriority('tags.handler-one', defaultPriorityTagMethod: 'getTaggedPriorityNonExist', requireDefaultPriorityMethod: true);
+        $def->geTagPriority('tags.handler-one', tagOptions(defaultPriorityMethod: 'getTaggedPriorityNonExist', requireDefaultPriorityMethod: true));
     }
 
     public static function dataProviderWrongReturnType(): \Generator
@@ -243,7 +246,7 @@ class TagTest extends TestCase
     {
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $def = (new DiDefinitionAutowire($class))
-            ->bindTag('tags.handler-one', priorityTagMethod: $method)
+            ->bindTag('tags.handler-one', options: tagOptions(priorityMethod: $method))
             ->setContainer($mockContainer)
         ;
 

--- a/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
@@ -216,7 +216,24 @@ class TagTest extends TestCase
         $this->assertNull($def->geTagPriority('tags.handler-one', tagOptions(defaultPriorityMethod: 'getTaggedPriorityNonExist')));
     }
 
-    public function testGetPriorityByDefaultPriorityTagMethodFailIsRequiredTrue(): void
+    public static function dataProviderDefaultPriorityTagMethodWrong(): \Generator
+    {
+        yield 'method not exist and is required set by `tagOptions`' => [
+            tagOptions(defaultPriorityMethod: 'getTaggedPriorityNonExist', defaultPriorityMethodIsRequired: true),
+        ];
+
+        yield 'method not exist and is required with raw array' => [
+            [
+                'defaultPriorityMethod' => 'getTaggedPriorityNonExist',
+                'defaultPriorityMethodIsRequired' => new \stdClass(), // convert to boolean
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderDefaultPriorityTagMethodWrong
+     */
+    public function testGetPriorityByDefaultPriorityTagMethodFailIsRequiredTrue(array $tagOptions): void
     {
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $def = (new DiDefinitionAutowire(TaggedClassBindTagOne::class))
@@ -227,7 +244,7 @@ class TagTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessage('method must be declared with public and static modifiers. Return type must be int, string, null');
 
-        $def->geTagPriority('tags.handler-one', tagOptions(defaultPriorityMethod: 'getTaggedPriorityNonExist', requireDefaultPriorityMethod: true));
+        $def->geTagPriority('tags.handler-one', $tagOptions);
     }
 
     public static function dataProviderWrongReturnType(): \Generator

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsImplementInterfaceTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsImplementInterfaceTest.php
@@ -28,6 +28,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
  *
  * @internal

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerCircularTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerCircularTest.php
@@ -30,6 +30,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
  */
 class TaggedAsThroughContainerCircularTest extends TestCase

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerTest.php
@@ -30,6 +30,7 @@ use function Kaspi\DiContainer\diValue;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
  * @covers \Kaspi\DiContainer\diTaggedAs
  * @covers \Kaspi\DiContainer\diValue
+ * @covers \Kaspi\DiContainer\tagOptions
  */
 class TaggedAsThroughContainerTest extends TestCase
 {

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
@@ -29,6 +29,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\AttributeReaderTrait
  */
 class TaggedAsThroughContainerVariadicTest extends TestCase

--- a/tests/FromDocs/Tags/Attributes/Fixtures/RuleA.php
+++ b/tests/FromDocs/Tags/Attributes/Fixtures/RuleA.php
@@ -7,7 +7,7 @@ namespace Tests\FromDocs\Tags\Attributes\Fixtures;
 use Kaspi\DiContainer\Attributes\Tag;
 
 #[Tag(name: 'tags.rules', priority: 10)]
-#[Tag(name: 'tags.rules.priorityMethod', priorityTagMethod: 'getPriority')]
+#[Tag(name: 'tags.rules.priorityMethod', priorityMethod: 'getPriority')]
 class RuleA implements RuleInterface
 {
     public static function getPriority(): string

--- a/tests/FromDocs/Tags/Attributes/Fixtures/RuleB.php
+++ b/tests/FromDocs/Tags/Attributes/Fixtures/RuleB.php
@@ -7,7 +7,7 @@ namespace Tests\FromDocs\Tags\Attributes\Fixtures;
 use Kaspi\DiContainer\Attributes\Tag;
 
 #[Tag(name: 'tags.rules-other', options: ['priority' => 100])]
-#[Tag(name: 'tags.rules.priorityMethod', priorityTagMethod: 'getPriorityOther')]
+#[Tag(name: 'tags.rules.priorityMethod', priorityMethod: 'getPriorityOther')]
 class RuleB implements RuleInterface
 {
     public static function getPriorityOther(): string

--- a/tests/FromDocs/Tags/Attributes/TaggedByTest.php
+++ b/tests/FromDocs/Tags/Attributes/TaggedByTest.php
@@ -31,6 +31,7 @@ use function Kaspi\DiContainer\diAutowire;
  * @covers \Kaspi\DiContainer\DiContainerFactory
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  */
 class TaggedByTest extends TestCase
 {

--- a/tests/FromDocs/Tags/Definitions/TaggedByTest.php
+++ b/tests/FromDocs/Tags/Definitions/TaggedByTest.php
@@ -19,6 +19,7 @@ use Tests\FromDocs\Tags\Definitions\Fixtures\Two;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diTaggedAs;
+use function Kaspi\DiContainer\tagOptions;
 
 /**
  * @internal
@@ -30,6 +31,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  */
 class TaggedByTest extends TestCase
 {
@@ -143,9 +145,9 @@ class TaggedByTest extends TestCase
                 ),
             diAutowire(One::class),
             diAutowire(RuleA::class)
-                ->bindTag(name: 'tags.rules', priorityTagMethod: 'getPriority'),
+                ->bindTag(name: 'tags.rules', options: tagOptions(priorityMethod: 'getPriority')),
             diAutowire(RuleB::class)
-                ->bindTag(name: 'tags.rules', priorityTagMethod: 'getPriorityOther'),
+                ->bindTag(name: 'tags.rules', options: tagOptions(priorityMethod: 'getPriorityOther')),
             diAutowire(RuleC::class)
                 ->bindTag(name: 'tags.rules'),
             diAutowire(Two::class),

--- a/tests/Tag/DefaultPriorityMethod/AsAttributeTest.php
+++ b/tests/Tag/DefaultPriorityMethod/AsAttributeTest.php
@@ -26,6 +26,7 @@ use function Kaspi\DiContainer\diAutowire;
  * @covers \Kaspi\DiContainer\DiContainerFactory
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\BindArgumentsTrait
  */
 class AsAttributeTest extends TestCase

--- a/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedFour.php
+++ b/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedFour.php
@@ -6,7 +6,7 @@ namespace Tests\Tag\DefaultPriorityMethod\Fixtures;
 
 use Kaspi\DiContainer\Attributes\Tag;
 
-#[Tag(name: 'tags.tag-a', options: [], priority: 3, priorityTagMethod: 'getPriority')]
+#[Tag(name: 'tags.tag-a', options: [], priority: 3, priorityMethod: 'getPriority')]
 final class TaggedFour implements TaggedInterface
 {
     public static function getPriority(): ?int

--- a/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedOne.php
+++ b/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedOne.php
@@ -6,7 +6,7 @@ namespace Tests\Tag\DefaultPriorityMethod\Fixtures;
 
 use Kaspi\DiContainer\Attributes\Tag;
 
-#[Tag(name: 'tags.one', options: [], priorityTagMethod: 'getPriority')]
+#[Tag(name: 'tags.one', options: [], priorityMethod: 'getPriority')]
 final class TaggedOne implements TaggedInterface
 {
     public static function getPriority(): int

--- a/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedTwo.php
+++ b/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedTwo.php
@@ -6,7 +6,7 @@ namespace Tests\Tag\DefaultPriorityMethod\Fixtures;
 
 use Kaspi\DiContainer\Attributes\Tag;
 
-#[Tag(name: 'tags.tag-a', options: [], priority: 3, priorityTagMethod: 'getPriority')]
+#[Tag(name: 'tags.tag-a', options: [], priority: 3, priorityMethod: 'getPriority')]
 final class TaggedTwo implements TaggedInterface
 {
     public static function getPriority(): int

--- a/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
@@ -24,6 +24,7 @@ use function Kaspi\DiContainer\diTaggedAs;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
  * @covers \Kaspi\DiContainer\diTaggedAs
+ * @covers \Kaspi\DiContainer\tagOptions
  * @covers \Kaspi\DiContainer\Traits\DefinitionIdentifierTrait
  *
  * @internal


### PR DESCRIPTION
Обновить интерфейсы для тегированных классов - избавится от override эфекта в наследуемых интерфейсах.