### PR TITLE
FinderClass can also return interfaces.

### DIFF
--- a/src/DiContainer/Finder/FinderClass.php
+++ b/src/DiContainer/Finder/FinderClass.php
@@ -74,18 +74,36 @@ final class FinderClass implements FinderClassInterface
                 continue;
             }
 
-            if ($token->is(\T_CLASS)
-                && null !== ($nextToken = $tokens[$index + 2] ?? null)
-                && \str_starts_with($namespace, $this->namespace)) {
-                $previousToken = $tokens[$index - 2] ?? null;
-
-                if ((null !== $previousToken && $previousToken->is(\T_ABSTRACT))
-                    || !\str_starts_with($namespace, $this->namespace)) {
-                    continue;
-                }
-
-                yield $keyOfClass++ => $namespace.($namespace ? '\\' : '').$nextToken->text; // @phpstan-ignore generator.valueType, ternary.condNotBoolean
+            if (\str_starts_with($namespace, $this->namespace)
+                && null !== ($f_q_c_n = $this->getFQCN($tokens, $token, $index, $namespace))) {
+                yield $keyOfClass++ => $f_q_c_n;
             }
         }
+    }
+
+    /**
+     * @param \PhpToken[] $tokens
+     *
+     * @return null|class-string
+     */
+    private function getFQCN(array $tokens, \PhpToken $token, int $index, string $namespace): ?string
+    {
+        if ($token->is(\T_CLASS)
+            && null !== ($nextToken = $tokens[$index + 2] ?? null)) {
+            $previousToken = $tokens[$index - 2] ?? null;
+
+            if (null !== $previousToken && $previousToken->is(\T_ABSTRACT)) {
+                return null;
+            }
+
+            return $namespace.($namespace ? '\\' : '').$nextToken->text; // @phpstan-ignore return.type, ternary.condNotBoolean
+        }
+
+        if ($token->is(\T_INTERFACE)
+            && null !== ($nextToken = $tokens[$index + 2] ?? null)) {
+            return $namespace.($namespace ? '\\' : '').$nextToken->text; // @phpstan-ignore return.type, ternary.condNotBoolean
+        }
+
+        return null;
     }
 }

--- a/src/DiContainer/Interfaces/Finder/FinderClassInterface.php
+++ b/src/DiContainer/Interfaces/Finder/FinderClassInterface.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\Finder;
 
+/**
+ * Find classes and interfaces in source files.
+ */
 interface FinderClassInterface
 {
     /**
+     * Get classes and interfaces.
+     *
      * @return \Iterator<non-negative-int, class-string>
      *
      * @throws \RuntimeException

--- a/src/DiContainer/Interfaces/Finder/FinderClassInterface.php
+++ b/src/DiContainer/Interfaces/Finder/FinderClassInterface.php
@@ -10,7 +10,7 @@ namespace Kaspi\DiContainer\Interfaces\Finder;
 interface FinderClassInterface
 {
     /**
-     * Get classes and interfaces.
+     * Get Fully Qualified Class Names for classes and interfaces.
      *
      * @return \Iterator<non-negative-int, class-string>
      *

--- a/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
@@ -38,18 +38,16 @@ class DefinitionsLoaderImportTest extends TestCase
             $classesNames[] = $definition->getDefinition()->getName();
         }
 
-        $this->assertEquals(
-            [],
-            \array_diff(
-                $classesNames,
-                [
-                    Fixtures\Import\SubDirectory\One::class,
-                    Fixtures\Import\SubDirectory\Two::class,
-                    Fixtures\Import\One::class,
-                    Fixtures\Import\Two::class,
-                ]
-            )
-        );
+        $expect = [
+            Fixtures\Import\SubDirectory\One::class,
+            Fixtures\Import\SubDirectory\Two::class,
+            Fixtures\Import\One::class,
+            Fixtures\Import\Two::class,
+            Fixtures\Import\TokenInterface::class,
+        ];
+
+        $this->assertCount(\count($expect), $classesNames);
+        $this->assertSame(\sort($expect), \sort($classesNames));
 
         // manual config in Fixtures/Import/services.php
         $this->assertEquals('baz-bar-foo', $container->get(Fixtures\Import\SubDirectory\One::class)->getToken());

--- a/tests/FinderClass/FinderClassTest.php
+++ b/tests/FinderClass/FinderClassTest.php
@@ -84,16 +84,19 @@ class FinderClassTest extends TestCase
         foreach ($classes as $class) {
             $foundClasses[] = $class;
         }
+        $expect = [
+            TwoInOneOne::class,
+            TwoInOneTow::class,
+            Fixtures\Success\WithTokenInterface::class,
+            ManyNamespaces::class,
+            Fixtures\Success\SomeInterface::class,
+            Fixtures\Success\Others\GetTokenInterface::class,
+            Fixtures\Success\Others\ManyNamespaces::class,
+            One::class,
+            Fixtures\Success\QueueInterface::class,
+        ];
 
-        $this->assertEquals(
-            [],
-            \array_diff([
-                TwoInOneOne::class,
-                TwoInOneTow::class,
-                ManyNamespaces::class,
-                Fixtures\Success\Others\ManyNamespaces::class,
-                One::class,
-            ], $foundClasses)
-        );
+        $this->assertCount(\count($expect), $foundClasses);
+        $this->assertSame(\sort($expect), \sort($foundClasses));
     }
 }

--- a/tests/FinderFile/FinderFileTest.php
+++ b/tests/FinderFile/FinderFileTest.php
@@ -73,16 +73,16 @@ class FinderFileTest extends TestCase
     public function testFilesWithTxtAndDocExtension(): void
     {
         $files = (new FinderFile(__DIR__.'/Fixtures', extensions: ['txt', 'doc']))->getFiles();
+        $expect = [
+            'document.doc',
+            'SomeFile.txt',
+            'Doc.txt',
+        ];
 
-        $this->assertEquals(
-            [
-                'document.doc',
-                'SomeFile.txt',
-                'Doc.txt',
-            ],
-            \array_diff(\array_map(static fn (\SplFileInfo $f) => $f->getFilename(), \iterator_to_array($files)), [
-            ]),
-        );
+        $found = \array_map(static fn (\SplFileInfo $f) => $f->getFilename(), \iterator_to_array($files));
+
+        $this->assertCount(\count($expect), $found);
+        $this->assertSame($expect, $found);
     }
 
     public function testFilesWithIgnoreExtension(): void


### PR DESCRIPTION
Get Fully Qualified Class Names for classes and interfaces by `FinderClass::getClasses()`