### PR TITLE
`DefinitionsLoader::definitions()` use `ReflectionClass` when configure definitions using the php attribute only.

### DIFF
--- a/src/DiContainer/Interfaces/Finder/FinderFullyQualifiedNameInterface.php
+++ b/src/DiContainer/Interfaces/Finder/FinderFullyQualifiedNameInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Interfaces\Finder;
 
 /**
+ * @phpstan-type ItemFQN array{fqn: class-string, tokenId: \T_CLASS | \T_INTERFACE}
+ *
  * Find classes and interfaces in source files.
  */
 interface FinderFullyQualifiedNameInterface
@@ -12,7 +14,7 @@ interface FinderFullyQualifiedNameInterface
     /**
      * Find all fully qualified names for classes and interfaces.
      *
-     * @return \Iterator<non-negative-int, class-string>
+     * @return \Iterator<non-negative-int, ItemFQN>
      *
      * @throws \RuntimeException
      */

--- a/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
@@ -57,7 +57,6 @@ class DefinitionsLoaderImportTest extends TestCase
             'services.two',
         ];
 
-        $this->assertCount(\count($expectContainerIds), $containerIds);
         \sort($expectContainerIds);
         \sort($containerIds);
         $this->assertEquals($expectContainerIds, $containerIds);

--- a/tests/FinderFullyQualifiedClassName/FinderFullyQualifiedClassNameTest.php
+++ b/tests/FinderFullyQualifiedClassName/FinderFullyQualifiedClassNameTest.php
@@ -6,10 +6,6 @@ namespace Tests\FinderFullyQualifiedClassName;
 
 use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
 use PHPUnit\Framework\TestCase;
-use Tests\FinderFullyQualifiedClassName\Fixtures\Success\ManyNamespaces;
-use Tests\FinderFullyQualifiedClassName\Fixtures\Success\One;
-use Tests\FinderFullyQualifiedClassName\Fixtures\Success\TwoInOneOne;
-use Tests\FinderFullyQualifiedClassName\Fixtures\Success\TwoInOneTow;
 
 /**
  * @covers \Kaspi\DiContainer\Finder\FinderFullyQualifiedName
@@ -85,15 +81,15 @@ class FinderFullyQualifiedClassNameTest extends TestCase
             $foundClasses[] = $class;
         }
         $expect = [
-            TwoInOneOne::class,
-            TwoInOneTow::class,
-            Fixtures\Success\WithTokenInterface::class,
-            ManyNamespaces::class,
-            Fixtures\Success\SomeInterface::class,
-            Fixtures\Success\Others\GetTokenInterface::class,
-            Fixtures\Success\Others\ManyNamespaces::class,
-            One::class,
-            Fixtures\Success\QueueInterface::class,
+            ['fqn' => Fixtures\Success\TwoInOneOne::class, 'tokenId' => \T_CLASS],
+            ['fqn' => Fixtures\Success\TwoInOneTow::class, 'tokenId' => \T_CLASS],
+            ['fqn' => Fixtures\Success\WithTokenInterface::class, 'tokenId' => \T_INTERFACE],
+            ['fqn' => Fixtures\Success\ManyNamespaces::class, 'tokenId' => \T_CLASS],
+            ['fqn' => Fixtures\Success\SomeInterface::class, 'tokenId' => \T_INTERFACE],
+            ['fqn' => Fixtures\Success\Others\GetTokenInterface::class, 'tokenId' => \T_INTERFACE],
+            ['fqn' => Fixtures\Success\Others\ManyNamespaces::class, 'tokenId' => \T_CLASS],
+            ['fqn' => Fixtures\Success\One::class, 'tokenId' => \T_CLASS],
+            ['fqn' => Fixtures\Success\QueueInterface::class, 'tokenId' => \T_INTERFACE],
         ];
 
         \sort($expect);


### PR DESCRIPTION
  - Refactor `FinderFullyQualifiedNameInterface::find()` return array aka `ItemFQN`.
- `ItemFQN` array{fqn: class-string, tokenId: \T_CLASS | \T_INTERFACE}
- `DefinitionsLoader::makeDefinitionFromReflectionClass()` call `ReflectionClass` when argument `$useAttribute` has `true`.
