### PR TITLE
`FinderFullyQualifiedNameInterface::find()` - change return type.

### DIFF
--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -96,7 +96,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
             foreach ($this->import as ['finderFQN' => $finderFQN, 'useAttribute' => $useAttribute]) {
                 /** @var ItemFQN $itemFQN */
                 foreach ($finderFQN->find() as $itemFQN) {
-                    if ([] !== ($definition = $this->makeDefinitionFromReflectionClass($itemFQN, $useAttribute))) {
+                    if ([] !== ($definition = $this->makeDefinitionFromItemFQN($itemFQN, $useAttribute))) {
                         yield from $definition;
                     }
                 }
@@ -133,7 +133,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
      * @throws DiDefinitionExceptionInterface
      * @throws \RuntimeException
      */
-    private function makeDefinitionFromReflectionClass(array $itemFQN, bool $useAttribute): array
+    private function makeDefinitionFromItemFQN(array $itemFQN, bool $useAttribute): array
     {
         ['fqn' => $fqn, 'tokenId' => $tokenId] = $itemFQN;
 
@@ -147,7 +147,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
             $reflectionClass = new \ReflectionClass($fqn);
         } catch (\ReflectionException $e) { // @phpstan-ignore catch.neverThrown
             throw new \RuntimeException(
-                message: \sprintf('%s. Got item: %s', $e->getMessage(), \var_export($itemFQN, true)),
+                message: \sprintf('Get fully qualified name "%s" from file "%s:%d" (line #%d). Reason: %s', $fqn, $itemFQN['file'], $itemFQN['line'], $itemFQN['line'], $e->getMessage()),
                 previous: $e
             );
         }

--- a/src/DiContainer/Finder/FinderFullyQualifiedName.php
+++ b/src/DiContainer/Finder/FinderFullyQualifiedName.php
@@ -138,6 +138,8 @@ final class FinderFullyQualifiedName implements FinderFullyQualifiedNameInterfac
                 yield $key++ => [
                     'fqn' => $fqn,
                     'tokenId' => $tokenId,
+                    'line' => \is_array($token) ? $token[2] : null,
+                    'file' => $file->getRealPath(),
                 ];
             }
         }

--- a/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
+++ b/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
@@ -6,6 +6,7 @@ namespace Kaspi\DiContainer\Interfaces;
 
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Psr\Container\ContainerExceptionInterface;
@@ -53,6 +54,8 @@ interface DefinitionsLoaderInterface
      * @return iterable<class-string|non-empty-string, DiDefinitionInterface|mixed>
      *
      * @throws DiDefinitionExceptionInterface
+     * @throws AutowireExceptionInterface
+     * @throws \RuntimeException
      */
     public function definitions(): iterable;
 

--- a/src/DiContainer/Interfaces/Finder/FinderFullyQualifiedNameInterface.php
+++ b/src/DiContainer/Interfaces/Finder/FinderFullyQualifiedNameInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Interfaces\Finder;
 
 /**
- * @phpstan-type ItemFQN array{fqn: class-string, tokenId: \T_CLASS | \T_INTERFACE}
+ * @phpstan-type ItemFQN array{fqn: class-string, tokenId: \T_CLASS | \T_INTERFACE, line: null|int, file: string}
  *
  * Find classes and interfaces in source files.
  */

--- a/tests/FinderFullyQualifiedClassName/FinderFullyQualifiedClassNameTest.php
+++ b/tests/FinderFullyQualifiedClassName/FinderFullyQualifiedClassNameTest.php
@@ -71,15 +71,16 @@ class FinderFullyQualifiedClassNameTest extends TestCase
     public function testGetClasses(): void
     {
         $dir = new \FilesystemIterator(__DIR__.'/Fixtures/Success/');
-        $classes = (new FinderFullyQualifiedName('Tests\\', $dir))->find();
+        $fqNames = (new FinderFullyQualifiedName('Tests\\', $dir))->find();
 
-        $this->assertTrue($classes->valid());
+        $this->assertTrue($fqNames->valid());
 
-        $foundClasses = [];
+        $foundFqn = [];
 
-        foreach ($classes as $class) {
-            $foundClasses[] = $class;
+        foreach ($fqNames as $fqn) {
+            $foundFqn[] = \array_filter($fqn, static fn (string $k) => \in_array($k, ['fqn', 'tokenId'], true), \ARRAY_FILTER_USE_KEY);
         }
+
         $expect = [
             ['fqn' => Fixtures\Success\TwoInOneOne::class, 'tokenId' => \T_CLASS],
             ['fqn' => Fixtures\Success\TwoInOneTow::class, 'tokenId' => \T_CLASS],
@@ -93,8 +94,8 @@ class FinderFullyQualifiedClassNameTest extends TestCase
         ];
 
         \sort($expect);
-        \sort($foundClasses);
+        \sort($foundFqn);
 
-        $this->assertEquals($expect, $foundClasses);
+        $this->assertEquals($expect, $foundFqn);
     }
 }


### PR DESCRIPTION
- Return type as \Iterator<non-negative-int, array{fqn: class-string, tokenId: \T_CLASS | \T_INTERFACE, line: null|int, file: string}>. Where array keys:
  - 'fqn' fully qualified name of class or interface;
  - 'tokenId' token id get by `token_get_all()`;
  - 'line' line number where get token;
  - 'file' pull path to file where is located token;