### PR TITLE
Release v3.14.0

### DIFF
--- a/src/DiContainer/Attributes/Setup.php
+++ b/src/DiContainer/Attributes/Setup.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Attributes;
+
+use Attribute;
+use Kaspi\DiContainer\Interfaces\Attributes\DiSetupAttributeInterface;
+use Kaspi\DiContainer\Traits\SetupTrait;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class Setup implements DiSetupAttributeInterface
+{
+    use SetupTrait;
+
+    public function isImmutable(): bool
+    {
+        return false;
+    }
+}

--- a/src/DiContainer/Attributes/SetupImmutable.php
+++ b/src/DiContainer/Attributes/SetupImmutable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Attributes;
+
+use Attribute;
+use Kaspi\DiContainer\Interfaces\Attributes\DiSetupAttributeInterface;
+use Kaspi\DiContainer\Traits\SetupTrait;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class SetupImmutable implements DiSetupAttributeInterface
+{
+    use SetupTrait;
+
+    public function isImmutable(): bool
+    {
+        return true;
+    }
+}

--- a/src/DiContainer/DiDefinition/DiDefinitionCallable.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionCallable.php
@@ -83,7 +83,7 @@ final class DiDefinitionCallable implements DiDefinitionArgumentsInterface, DiDe
             return $this->getDefinition()();
         }
 
-        return $this->getDefinition()(...$this->resolveParameters($this->getBindArguments(), $this->reflectedFunctionParameters));
+        return $this->getDefinition()(...$this->resolveParameters($this->getBindArguments(), $this->reflectedFunctionParameters, true));
     }
 
     /**

--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -16,8 +16,8 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerNeedSetExceptionInterface;
 use Kaspi\DiContainer\LazyDefinitionIterator;
+use Kaspi\DiContainer\Traits\DiAutowireTrait;
 use Kaspi\DiContainer\Traits\DiContainerTrait;
-use Kaspi\DiContainer\Traits\DiDefinitionAutowireTrait;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use SplPriorityQueue;
@@ -35,7 +35,7 @@ use function var_export;
 final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDefinitionNoArgumentsInterface
 {
     use DiContainerTrait;
-    use DiDefinitionAutowireTrait;
+    use DiAutowireTrait;
 
     private bool $tagIsInterface;
     private string $keyOptimized;

--- a/src/DiContainer/Interfaces/Attributes/DiSetupAttributeInterface.php
+++ b/src/DiContainer/Interfaces/Attributes/DiSetupAttributeInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\Attributes;
+
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInvokableInterface;
+
+interface DiSetupAttributeInterface extends DiAttributeInterface
+{
+    public function isImmutable(): bool;
+
+    /**
+     * @return (DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed)[]
+     */
+    public function getArguments(): array;
+
+    /**
+     * @param non-empty-string $method
+     */
+    public function setMethod(string $method): void;
+
+    /**
+     * @return non-empty-string
+     */
+    public function getIdentifier(): string;
+}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
@@ -7,19 +7,24 @@ namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 interface DiDefinitionConfigAutowireInterface extends DiDefinitionArgumentsInterface
 {
     /**
-     * Call setter method for class with input arguments.
+     * Call setter method for class with input arguments without return type aka void.
      * Calling method may use autowire feature.
      * This method can be used many times.
      * Arguments provided by the user added by name or index.
+     * Arguments can be mixed types
+     * or presented as object implemented DiDefinitionInterface, DiDefinitionArgumentsInterface, DiDefinitionInvokableInterface.
      *
      * User can set arguments by named argument:
      *
-     *       setup('classMethod', var1: 'value 1', var2: 'value 2')
+     *       ->setup('classMethod', var1: 'value 1', var2: 'value 2')
      *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
+     *
+     *       ->setup('classMethod', var1: new DiDefinitionGet('service.one'))
+     *       ->setup('classMethod', var1: new DiDefinitionGet('service.two'))
      *
      * User can set arguments by index argument:
      *
-     *      setup('classMethod', 'value 1', 'value 2')
+     *      ->setup('classMethod', 'value 1', 'value 2')
      *      // bind parameters by index Class->classMethod('value 1', 'value 2')
      *
      * @param non-empty-string                                                                          $method
@@ -28,4 +33,32 @@ interface DiDefinitionConfigAutowireInterface extends DiDefinitionArgumentsInter
      * @return $this
      */
     public function setup(string $method, mixed ...$argument): static;
+
+    /**
+     * Call immutable setter method for class with input arguments with return type aka self.
+     * Calling method may use autowire feature.
+     * This method can be used many times.
+     * Arguments provided by the user added by name or index.
+     * Arguments can be mixed types
+     * or presented as object implemented DiDefinitionInterface, DiDefinitionArgumentsInterface, DiDefinitionInvokableInterface.
+     *
+     * User can set arguments by named argument:
+     *
+     *       ->setupImmutable('classMethod', var1: 'value 1', var2: 'value 2')
+     *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
+     *
+     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.one'))
+     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.two'))
+     *
+     * User can set arguments by index argument:
+     *
+     *      ->setupImmutable('classMethod', 'value 1', 'value 2')
+     *      // bind parameters by index Class->classMethod('value 1', 'value 2')
+     *
+     * @param non-empty-string                                                                          $method
+     * @param DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed ...$argument
+     *
+     * @return $this
+     */
+    public function setupImmutable(string $method, mixed ...$argument): static;
 }

--- a/src/DiContainer/Traits/DiAutowireTrait.php
+++ b/src/DiContainer/Traits/DiAutowireTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Traits;
 
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use ReflectionNamedType;
+use ReflectionType;
 use ReflectionUnionType;
 
 use function array_diff;
@@ -15,9 +17,11 @@ use function implode;
 use function is_callable;
 use function is_string;
 use function sprintf;
+use function str_starts_with;
+use function substr;
 use function trim;
 
-trait DiDefinitionAutowireTrait
+trait DiAutowireTrait
 {
     /**
      * @param non-empty-string                          $where
@@ -56,7 +60,7 @@ trait DiDefinitionAutowireTrait
     /**
      * @return array<string>
      */
-    private static function diffReturnType(null|ReflectionNamedType|ReflectionUnionType $returnType, string ...$type): array
+    private static function diffReturnType(?ReflectionType $returnType, string ...$type): array
     {
         $fn = static fn (ReflectionNamedType $t): string => $t->getName();
 
@@ -67,5 +71,24 @@ trait DiDefinitionAutowireTrait
         };
 
         return array_diff($types, $type);
+    }
+
+    /**
+     * Convention for string value in argument:
+     *  - 'raw str' raw value, as is
+     * - '@container-identifier' convert to new DiDefinitionGet('container-identifier')
+     * - '@@container-identifier' convert to string '@container-identifier'
+     */
+    private static function convertStringArgumentToDiDefinitionGet(mixed $arg): mixed
+    {
+        if (is_string($arg) && str_starts_with($arg, '@')) {
+            return match (true) {
+                str_starts_with($arg, '@@') => substr($arg, 1),
+                '' !== ($id = substr($arg, 1)) => new DiDefinitionGet($id),
+                default => $arg
+            };
+        }
+
+        return $arg;
     }
 }

--- a/src/DiContainer/Traits/SetupTrait.php
+++ b/src/DiContainer/Traits/SetupTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Traits;
+
+use Kaspi\DiContainer\Exception\AutowireAttributeException;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInvokableInterface;
+
+use function preg_match;
+use function sprintf;
+
+trait SetupTrait
+{
+    /** @var non-empty-string */
+    private string $method;
+
+    /** @var (DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed)[] */
+    private array $arguments = [];
+
+    /**
+     * @param (DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed) ...$argument
+     */
+    public function __construct(mixed ...$argument)
+    {
+        $this->arguments = $argument;
+    }
+
+    /**
+     * @return (DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed)[]
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getIdentifier(): string
+    {
+        return $this->method ?? throw new AutowireAttributeException('The private value $method is not defined.');
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    public function setMethod(string $method): void
+    {
+        // @see https://www.php.net/manual/en/language.variables.basics.php
+        if (1 !== preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $method)) {
+            throw new AutowireAttributeException(sprintf('The $method parameter must be a valid method name. Got: %s', $method));
+        }
+
+        $this->method = $method;
+    }
+}

--- a/src/DiContainer/Traits/TagsTrait.php
+++ b/src/DiContainer/Traits/TagsTrait.php
@@ -27,11 +27,7 @@ trait TagsTrait
      */
     public function bindTag(string $name, array $options = [], null|int|string $priority = null): static
     {
-        $this->tags[$name] = $options;
-
-        if (null !== $priority) {
-            $this->tags[$name]['priority'] = $priority;
-        }
+        $this->tags[$name] = static::transformTagOptions($options, $priority);
 
         return $this;
     }
@@ -46,14 +42,12 @@ trait TagsTrait
 
     public function getTag(string $name): ?array
     {
-        return $this->hasTag($name)
-            ? $this->tags[$name]
-            : null;
+        return $this->getTags()[$name] ?? null;
     }
 
     public function hasTag(string $name): bool
     {
-        return [] !== $this->tags && isset($this->tags[$name]);
+        return isset($this->getTags()[$name]);
     }
 
     /**
@@ -67,5 +61,15 @@ trait TagsTrait
         return [] !== $options && array_key_exists('priority', $options) && (is_int($priority = $options['priority']) || is_string($priority))
             ? $priority
             : null;
+    }
+
+    /**
+     * @param TagOptions $options tag's meta-data
+     *
+     * @return TagOptions
+     */
+    private static function transformTagOptions(array $options = [], null|int|string $priority = null): array
+    {
+        return (null === $priority ? [] : ['priority' => $priority]) + $options;
     }
 }

--- a/tests/Attributes/Raw/SetupAndSetupImmutableTest.php
+++ b/tests/Attributes/Raw/SetupAndSetupImmutableTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Attributes\Raw;
+
+use Generator;
+use Kaspi\DiContainer\Attributes\Setup;
+use Kaspi\DiContainer\Attributes\SetupImmutable;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use PHPUnit\Framework\TestCase;
+
+use function Kaspi\DiContainer\diGet;
+
+/**
+ * @covers \Kaspi\DiContainer\Attributes\Setup
+ * @covers \Kaspi\DiContainer\Attributes\SetupImmutable
+ * @covers \Kaspi\DiContainer\diAutowire
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
+ * @covers \Kaspi\DiContainer\diGet
+ *
+ * @internal
+ */
+class SetupAndSetupImmutableTest extends TestCase
+{
+    public function testFailSetupNotSetMethod(): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+
+        (new Setup())->getIdentifier();
+    }
+
+    public function testFailSetupImmutableNotSetMethod(): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+
+        (new SetupImmutable())->getIdentifier();
+    }
+
+    public function dataProviderMethod(): Generator
+    {
+        yield 'empty string' => [''];
+
+        yield 'string with spaces' => ['   '];
+
+        yield 'not valid string "11111"' => ['11111'];
+
+        yield 'not valid string "1method"' => ['1method'];
+
+        yield 'not valid string "method method"' => ['method method'];
+
+        yield 'not valid string " method"' => [' method'];
+    }
+
+    /**
+     * @dataProvider dataProviderMethod
+     */
+    public function testFailSetupSetMethod(string $method): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+
+        $s = new Setup();
+        $s->setMethod($method);
+    }
+
+    /**
+     * @dataProvider dataProviderMethod
+     */
+    public function testFailSetupImmutableSetMethod(string $method): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+
+        $s = new SetupImmutable();
+        $s->setMethod($method);
+    }
+
+    public function dataProviderSuccessMethod(): Generator
+    {
+        yield 'success name #1' => ['withLogger'];
+
+        yield 'success name #2' => ['setLogger'];
+
+        yield 'success name #3' => ['set2'];
+
+        yield 'success name #4' => ['with1'];
+
+        yield 'success name #5' => ['a'];
+    }
+
+    /**
+     * @dataProvider dataProviderSuccessMethod
+     */
+    public function testSuccessSetupSetMethod(string $method): void
+    {
+        $s = new Setup();
+        $s->setMethod($method);
+
+        self::assertEquals($method, $s->getIdentifier());
+        self::assertEquals([], $s->getArguments());
+        self::assertFalse($s->isImmutable());
+    }
+
+    /**
+     * @dataProvider dataProviderSuccessMethod
+     */
+    public function testSuccessSetupImmutableSetMethod(string $method): void
+    {
+        $s = new SetupImmutable();
+        $s->setMethod($method);
+
+        self::assertEquals($method, $s->getIdentifier());
+        self::assertEquals([], $s->getArguments());
+        self::assertTrue($s->isImmutable());
+    }
+
+    public function testSetupNamedArgument(): void
+    {
+        $s = new Setup(one: 'first', two: 'second');
+
+        self::assertEquals(['one' => 'first', 'two' => 'second'], $s->getArguments());
+    }
+
+    public function testSetupImmutableNamedArgument(): void
+    {
+        $s = new SetupImmutable(one: 'first', two: 'second');
+
+        self::assertEquals(['one' => 'first', 'two' => 'second'], $s->getArguments());
+    }
+
+    public function testSetupMixedNamedArgument(): void
+    {
+        $s = new Setup('first', two: 'second');
+
+        self::assertEquals([0 => 'first', 'two' => 'second'], $s->getArguments());
+        self::assertFalse($s->isImmutable());
+    }
+
+    public function testSetupImmutableMixedNamedArgument(): void
+    {
+        $s = new SetupImmutable('first', two: 'second');
+
+        self::assertEquals([0 => 'first', 'two' => 'second'], $s->getArguments());
+        self::assertTrue($s->isImmutable());
+    }
+
+    public function testSetupMixedNamedArgumentWithValueAsObject(): void
+    {
+        $s = new Setup('first', two: diGet('service.one'));
+
+        self::assertEquals([0 => 'first', 'two' => diGet('service.one')], $s->getArguments());
+        self::assertFalse($s->isImmutable());
+    }
+
+    public function testSetupImmutableMixedNamedArgumentWithValueAsObject(): void
+    {
+        $s = new SetupImmutable('first', two: diGet('service.one'));
+
+        self::assertEquals([0 => 'first', 'two' => diGet('service.one')], $s->getArguments());
+        self::assertTrue($s->isImmutable());
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/ClassWithConstructDestruct.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/ClassWithConstructDestruct.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+final class ClassWithConstructDestruct
+{
+    public function __construct() {}
+
+    public function __destruct() {}
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupByAttributeWithArgumentAsReference.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupByAttributeWithArgumentAsReference.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Setup;
+
+final class SetupByAttributeWithArgumentAsReference
+{
+    public SomeClass $dependencyAutoResolve;
+    private ?SomeClass $someClass = null;
+    private ?string $anyAsContainerIdentifier = null;
+    private ?string $anyAsEscapedString = null;
+
+    private ?string $anyAsString = null;
+
+    /**
+     * Will return SomeClass::SomeClass.
+     */
+    public function getSomeClass(): ?SomeClass
+    {
+        return $this->someClass;
+    }
+
+    /**
+     * Will return value from the container mock object.
+     */
+    public function getAnyAsContainerIdentifier(): ?string
+    {
+        return $this->anyAsContainerIdentifier;
+    }
+
+    /**
+     * Will return string "@la-la-la".
+     */
+    public function getAnyAsEscapedString(): ?string
+    {
+        return $this->anyAsEscapedString;
+    }
+
+    /**
+     * Will return "la-la-la".
+     */
+    public function getAnyAsString(): ?string
+    {
+        return $this->anyAsString;
+    }
+
+    #[Setup(someClass: '@services.some_class')]
+    public function setSomeClassAsContainerIdentifier($someClass, SomeClass $class): void
+    {
+        $this->someClass = $someClass;
+        $this->dependencyAutoResolve = $class;
+    }
+
+    #[Setup(any: '@services.any_string')]
+    public function setAnyAsContainerIdentifier(string $any): void
+    {
+        $this->anyAsContainerIdentifier = $any;
+    }
+
+    #[Setup(any: '@@la-la-la')]
+    public function setAnyAsEscapedString(string $any): void
+    {
+        $this->anyAsEscapedString = $any;
+    }
+
+    #[Setup(anyAsString: 'la-la-la')]
+    public function setAnyAsString(string $anyAsString): void
+    {
+        $this->anyAsString = $anyAsString;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupClassByAttribute.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupClassByAttribute.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Setup;
+
+class SetupClassByAttribute
+{
+    private int $inc;
+    private array $parameters = [];
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    #[Setup(paramName: 'abc', parameters: ['one', 'two', 'three'])]
+    #[Setup(paramName: 'path', parameters: ['/tmp', '/var/cache'])]
+    public function setParameters(string $paramName, array $parameters): void
+    {
+        $this->parameters[$paramName] = $parameters;
+    }
+
+    #[Setup] // 1
+    #[Setup] // 2
+    #[Setup] // 3
+    #[Setup] // 4
+    public function incInc(): void
+    {
+        isset($this->inc) ? $this->inc++ : $this->inc = 1;
+    }
+
+    public function getInc(): int
+    {
+        return $this->inc;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutable.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutable.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+final class SetupImmutable
+{
+    private ?SomeClass $someClass = null;
+
+    public function __construct() {}
+
+    public function getSomeClass(): ?SomeClass
+    {
+        return $this->someClass;
+    }
+
+    public function withSomeClassClonedReturnSelf(SomeClass $someClass): self
+    {
+        $new = clone $this;
+        $new->someClass = $someClass;
+
+        return $new;
+    }
+
+    public function withSomeClassClonedReturnSameClass(SomeClass $someClass): SetupImmutable
+    {
+        $new = clone $this;
+        $new->someClass = $someClass;
+
+        return $new;
+    }
+
+    public function withSomeClassClonedNotReturnTypehint(SomeClass $someClass)
+    {
+        $new = clone $this;
+        $new->someClass = $someClass;
+
+        return $new;
+    }
+
+    public function withSomeClassNotClonedReturnSelf(SomeClass $someClass): self
+    {
+        $this->someClass = $someClass;
+
+        return $this;
+    }
+
+    public function withSomeClassFailReturnType(SomeClass $someClass): SomeClass
+    {
+        return $this->someClass = $someClass;
+    }
+
+    public function withSomeClassFailReturnObject(SomeClass $someClass)
+    {
+        return $this->someClass = $someClass;
+    }
+
+    public function withSomeClassFailReturnTypehintVoid(SomeClass $someClass): void
+    {
+        $this->someClass = $someClass;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttribute.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttribute.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\SetupImmutable;
+
+final class SetupImmutableByAttribute
+{
+    private ?SomeClass $someClass = null;
+
+    #[SetupImmutable]
+    public function withSomeClass(?SomeClass $someClass): self
+    {
+        $new = clone $this;
+        $new->someClass = $someClass;
+
+        return $new;
+    }
+
+    public function getSomeClass(): ?SomeClass
+    {
+        return $this->someClass;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttributeWithArgumentAsReference.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttributeWithArgumentAsReference.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\SetupImmutable;
+
+final class SetupImmutableByAttributeWithArgumentAsReference
+{
+    private ?SomeClass $someClass = null;
+    private ?string $anyAsContainerIdentifier = null;
+    private ?string $anyAsEscapedString = null;
+
+    private ?string $anyAsString = null;
+
+    /**
+     * Will return SomeClass::SomeClass.
+     */
+    public function getSomeClass(): ?SomeClass
+    {
+        return $this->someClass;
+    }
+
+    /**
+     * Will return value from the container mock object.
+     */
+    public function getAnyAsContainerIdentifier(): ?string
+    {
+        return $this->anyAsContainerIdentifier;
+    }
+
+    /**
+     * Will return string "@la-la-la".
+     */
+    public function getAnyAsEscapedString(): ?string
+    {
+        return $this->anyAsEscapedString;
+    }
+
+    /**
+     * Will return "any_string".
+     */
+    public function getAnyAsString(): ?string
+    {
+        return $this->anyAsString;
+    }
+
+    #[SetupImmutable(someClass: '@services.some_class')]
+    public function withSomeClassAsContainerIdentifier($someClass): self
+    {
+        $new = clone $this;
+        $new->someClass = $someClass;
+
+        return $new;
+    }
+
+    #[SetupImmutable(any: '@services.any_string')]
+    public function withAnyAsContainerIdentifier(string $any): self
+    {
+        $new = clone $this;
+        $new->anyAsContainerIdentifier = $any;
+
+        return $new;
+    }
+
+    #[SetupImmutable(any: '@@la-la-la')]
+    public function withAnyAsEscapedString(string $any): self
+    {
+        $new = clone $this;
+        $new->anyAsEscapedString = $any;
+
+        return $new;
+    }
+
+    #[SetupImmutable(anyAsString: 'any_string')]
+    public function withAnyAsString(string $anyAsString): self
+    {
+        $new = clone $this;
+        $new->anyAsString = $anyAsString;
+
+        return $new;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SomeClass.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SomeClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+final class SomeClass
+{
+    public function __construct(private ?string $value = null) {}
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire;
+
+use Generator;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\Exception\AutowireException;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use PHPUnit\Framework\TestCase;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\ClassWithConstructDestruct;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutable;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutableByAttribute;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutableByAttributeWithArgumentAsReference;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SomeClass;
+
+use function Kaspi\DiContainer\diAutowire;
+
+/**
+ * @covers \Kaspi\DiContainer\Attributes\SetupImmutable
+ * @covers \Kaspi\DiContainer\diAutowire
+ * @covers \Kaspi\DiContainer\DiContainerConfig
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\diGet
+ * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
+ *
+ * @internal
+ */
+class SetupImmutableTest extends TestCase
+{
+    private DiContainerInterface $mockContainer;
+
+    public function setUp(): void
+    {
+        $this->mockContainer = $this->createMock(DiContainerInterface::class);
+        $this->mockContainer->method('get')
+            ->with(SomeClass::class)
+            ->willReturn(new SomeClass())
+        ;
+    }
+
+    public function dataProviderImmutableSuccess(): Generator
+    {
+        yield 'for method withSomeClassClonedReturnSelf' => ['withSomeClassClonedReturnSelf'];
+
+        yield 'for method withSomeClassClonedReturnSameClass' => ['withSomeClassClonedReturnSameClass'];
+
+        yield 'for method withSomeClassClonedNotReturnTypehint' => ['withSomeClassClonedNotReturnTypehint'];
+
+        yield 'for method withSomeClassNotClonedReturnSelf' => ['withSomeClassNotClonedReturnSelf'];
+    }
+
+    /**
+     * @dataProvider dataProviderImmutableSuccess
+     */
+    public function testImmutableSuccess(string $method): void
+    {
+        $def = (new DiDefinitionAutowire(SetupImmutable::class, isSingleton: true))
+            ->setupImmutable($method) // argument $someClass resolve by typehint.
+            ->setContainer($this->mockContainer)
+        ;
+
+        /** @var SetupImmutable $setupImmutableClass */
+        $setupImmutableClass = $def->invoke();
+
+        self::assertInstanceOf(SetupImmutable::class, $setupImmutableClass);
+        self::assertInstanceOf(SomeClass::class, $setupImmutableClass->getSomeClass());
+    }
+
+    public function dataProviderImmutableFail(): Generator
+    {
+        yield 'for method withSomeClassFailReturnType' => ['withSomeClassFailReturnType'];
+
+        yield 'for method withSomeClassFailReturnObject' => ['withSomeClassFailReturnObject'];
+
+        yield 'for method withSomeClassFailReturnTypehintVoid' => ['withSomeClassFailReturnTypehintVoid'];
+    }
+
+    /**
+     * @dataProvider dataProviderImmutableFail
+     */
+    public function testImmutableFail(string $method): void
+    {
+        $def = (new DiDefinitionAutowire(SetupImmutable::class, isSingleton: true))
+            ->setupImmutable($method) // argument $someClass resolve by typehint.
+            ->setContainer($this->mockContainer)
+        ;
+
+        $this->expectException(AutowireException::class);
+        $this->expectExceptionMessageMatches('/The immutable setter .+SetupImmutable::'.$method.'\(\)" must return same class/');
+
+        /** @var SetupImmutable $setupImmutableClass */
+        $setupImmutableClass = $def->invoke();
+    }
+
+    public function testSetupImmutableByAttribute(): void
+    {
+        $this->mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+
+        $def = (new DiDefinitionAutowire(SetupImmutableByAttribute::class))
+            ->setContainer($this->mockContainer)
+        ;
+
+        $setupImmutableClass = $def->invoke();
+
+        self::assertInstanceOf(SomeClass::class, $setupImmutableClass->getSomeClass());
+    }
+
+    public function testSetupImmutableByAttributeWithoutConfigUseAttribute(): void
+    {
+        $this->mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: false))
+        ;
+
+        $def = (new DiDefinitionAutowire(SetupImmutableByAttribute::class))
+            ->setContainer($this->mockContainer)
+        ;
+
+        $setupImmutableClass = $def->invoke();
+
+        self::assertNull($setupImmutableClass->getSomeClass());
+    }
+
+    public function testSetupImmutableByAttributeWithOverrideDefinitionSetup(): void
+    {
+        $this->mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+
+        $def = (new DiDefinitionAutowire(SetupImmutableByAttribute::class))
+            ->setupImmutable('withSomeClass', someClass: null)
+            ->setupImmutable('withSomeClass', someClass: diAutowire(SomeClass::class)->bindArguments('aaa'))
+
+            ->setContainer($this->mockContainer)
+        ;
+
+        $setupImmutableClass = $def->invoke();
+
+        self::assertInstanceOf(SomeClass::class, $setupImmutableClass->getSomeClass());
+        self::assertNull($setupImmutableClass->getSomeClass()->getValue());
+    }
+
+    public function testSetupImmutableByAttributeStringArgumentAsDiGet(): void
+    {
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+        $mockContainer->method('get')
+            ->willReturnMap([
+                ['services.some_class', new SomeClass('foo')],
+                ['services.any_string', 'string from container'],
+            ])
+        ;
+
+        $def = (new DiDefinitionAutowire(SetupImmutableByAttributeWithArgumentAsReference::class))
+            ->setupImmutable('withSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setContainer($mockContainer)
+        ;
+
+        /** @var SetupImmutableByAttributeWithArgumentAsReference $class */
+        $class = $def->invoke();
+
+        self::assertInstanceOf(SomeClass::class, $class->getSomeClass());
+        self::assertEquals('foo', $class->getSomeClass()->getValue());
+
+        self::assertEquals('string from container', $class->getAnyAsContainerIdentifier());
+        self::assertEquals('@la-la-la', $class->getAnyAsEscapedString());
+        self::assertEquals('any_string', $class->getAnyAsString());
+    }
+
+    public function dataProviderSetupOnMethod(): Generator
+    {
+        yield 'on construct setup method' => [ClassWithConstructDestruct::class, '__construct'];
+
+        yield 'on destruct setup method' => [ClassWithConstructDestruct::class, '__destruct'];
+    }
+
+    /**
+     * @dataProvider dataProviderSetupOnMethod
+     */
+    public function testSetupOnMethod(string $class, string $method): void
+    {
+        $def = (new DiDefinitionAutowire($class))
+            ->setupImmutable($method)
+            ->setContainer($this->createMock(DiContainerInterface::class))
+        ;
+
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/Cannot use.+'.$method.'\(\) as setter/');
+
+        $def->invoke();
+    }
+}

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
@@ -4,14 +4,28 @@ declare(strict_types=1);
 
 namespace Tests\DiDefinition\DiDefinitionAutowire;
 
+use Generator;
+use Kaspi\DiContainer\DiContainerConfig;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use PHPUnit\Framework\TestCase;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\ClassWithConstructDestruct;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupByAttributeWithArgumentAsReference;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupClass;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupClassByAttribute;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SomeClass;
+
+use function Kaspi\DiContainer\diValue;
 
 /**
+ * @covers \Kaspi\DiContainer\Attributes\Setup
+ * @covers \Kaspi\DiContainer\DiContainerConfig
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet::getDefinition
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
+ * @covers \Kaspi\DiContainer\diValue
+ * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait::getParameterType
  *
  * @internal
  */
@@ -22,9 +36,9 @@ class SetupTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
 
         $def = (new DiDefinitionAutowire(SetupClass::class))
-            ->setup('setName', newName: 'Vasiliy') // first set name
-            ->setup('setName', 'Piter') // override set name
-            ->setup('setParameters', paramName: 'key1', parameters: ['One', 'Two', 'Three'])
+            ->setup('setName', newName: diValue('Vasiliy')) // first set name
+            ->setup('setName', diValue('Piter')) // override set name
+            ->setup('setParameters', paramName: diValue('key1'), parameters: ['One', 'Two', 'Three'])
             ->setup('setParameters', 'key2', ['Four', 'Five', 'Six'])
         ;
         $def->setContainer($mockContainer);
@@ -44,11 +58,12 @@ class SetupTest extends TestCase
     public function testSetupMethodNotExist(): void
     {
         $def = (new DiDefinitionAutowire(SetupClass::class))
+            ->setContainer($this->createMock(DiContainerInterface::class))
             ->setup('methodNotExist')
         ;
 
         $this->expectException(AutowireExceptionInterface::class);
-        $this->expectExceptionMessage('The method "methodNotExist" does not exist');
+        $this->expectExceptionMessageMatches('/The setter method.+\SetupClass::methodNotExist\(\)" does not exist/');
 
         $def->invoke();
     }
@@ -56,6 +71,7 @@ class SetupTest extends TestCase
     public function testSetupWithoutParameters(): void
     {
         $def = (new DiDefinitionAutowire(SetupClass::class))
+            ->setContainer($this->createMock(DiContainerInterface::class))
             ->setup('incInc')
             ->setup('incInc')
             ->setup('incInc')
@@ -64,5 +80,90 @@ class SetupTest extends TestCase
         $class = $def->invoke();
 
         $this->assertEquals(3, $class->getInc());
+    }
+
+    public function testSetupByAttribute(): void
+    {
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+
+        // #[Setup] on `incInc` method call 4 times.
+        // #[Setup] on `setParameters` method call 2 times with arguments.
+        $def = (new DiDefinitionAutowire(SetupClassByAttribute::class))
+            ->setContainer($mockContainer)
+            ->setup('incInc')// override by php attribute #[Setup]
+            ->setup('incInc') // override by php attribute #[Setup]
+            ->setup('incInc') // override by php attribute #[Setup]
+            ->setup('setParameters', 'key1', ['One', 'Two', 'Three']) // override by php attribute #[Setup]
+            ->setup('setParameters', 'key2', ['X', 'Y', 'Z']) // override by php attribute #[Setup]
+        ;
+
+        /** @var SetupClassByAttribute $class */
+        $class = $def->invoke();
+
+        self::assertEquals(4, $class->getInc());
+        self::assertSame(
+            [
+                'abc' => ['one', 'two', 'three'],
+                'path' => ['/tmp', '/var/cache'],
+            ],
+            $class->getParameters()
+        );
+    }
+
+    public function testSetupByAttributeStringArgumentAsDiGet(): void
+    {
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+        $mockContainer->method('get')
+            ->willReturnMap([
+                ['services.some_class', new SomeClass('foo')],
+                [SomeClass::class, new SomeClass('baz')],
+                ['services.any_string', 'string from container'],
+            ])
+        ;
+
+        $def = (new DiDefinitionAutowire(SetupByAttributeWithArgumentAsReference::class))
+            ->setup('setSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setContainer($mockContainer)
+        ;
+
+        /** @var SetupByAttributeWithArgumentAsReference $class */
+        $class = $def->invoke();
+
+        self::assertInstanceOf(SomeClass::class, $class->getSomeClass());
+        self::assertEquals('baz', $class->dependencyAutoResolve->getValue());
+        self::assertEquals('foo', $class->getSomeClass()->getValue());
+
+        self::assertEquals('string from container', $class->getAnyAsContainerIdentifier());
+        self::assertEquals('@la-la-la', $class->getAnyAsEscapedString());
+        self::assertEquals('la-la-la', $class->getAnyAsString());
+    }
+
+    public function dataProviderSetupOnMethod(): Generator
+    {
+        yield 'on construct setup method' => [ClassWithConstructDestruct::class, '__construct'];
+
+        yield 'on destruct setup method' => [ClassWithConstructDestruct::class, '__destruct'];
+    }
+
+    /**
+     * @dataProvider dataProviderSetupOnMethod
+     */
+    public function testSetupOnMethod(string $class, string $method): void
+    {
+        $def = (new DiDefinitionAutowire($class))
+            ->setup($method)
+            ->setContainer($this->createMock(DiContainerInterface::class))
+        ;
+
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/Cannot use.+'.$method.'\(\) as setter/');
+
+        $def->invoke();
     }
 }

--- a/tests/FromDocs/PhpAttribute/Fixtures/RuleGeneratorInjectRepeat.php
+++ b/tests/FromDocs/PhpAttribute/Fixtures/RuleGeneratorInjectRepeat.php
@@ -11,8 +11,7 @@ class RuleGeneratorInjectRepeat
     private iterable $rules;
 
     public function __construct(
-        #[Inject(RuleB::class)]
-        #[Inject(RuleA::class)]
+        #[Inject(RuleB::class), Inject(RuleA::class)]
         RuleInterface ...$inputRule
     ) {
         $this->rules = $inputRule;

--- a/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedPriorityVsMethodPriority.php
+++ b/tests/Tag/DefaultPriorityMethod/Fixtures/TaggedPriorityVsMethodPriority.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tag\DefaultPriorityMethod\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[Tag('tags.priority_vs_method_priority', priority: 10, priorityMethod: 'getPriority')]
+final class TaggedPriorityVsMethodPriority
+{
+    public static function getPriority(): string
+    {
+        return 'group:10:0001';
+    }
+
+    public static function getPriorityByPhpDefinition(): string
+    {
+        return 'group:20:2000';
+    }
+}

--- a/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupImmutableOnConstructor.php
+++ b/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupImmutableOnConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits\AttributeReader\SetupAttribute\Fixtures;
+
+use Kaspi\DiContainer\Attributes\SetupImmutable;
+
+final class SetupImmutableOnConstructor
+{
+    #[SetupImmutable('x')]
+    public function __construct(private string $value) {}
+}

--- a/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupImmutableOnDestructor.php
+++ b/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupImmutableOnDestructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits\AttributeReader\SetupAttribute\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Setup;
+
+final class SetupImmutableOnDestructor
+{
+    #[Setup]
+    public function __destruct() {}
+}

--- a/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupOnConstructor.php
+++ b/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupOnConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits\AttributeReader\SetupAttribute\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Setup;
+
+final class SetupOnConstructor
+{
+    #[Setup('x')]
+    public function __construct(private string $value) {}
+}

--- a/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupOnDestructor.php
+++ b/tests/Traits/AttributeReader/SetupAttribute/Fixtures/SetupOnDestructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits\AttributeReader\SetupAttribute\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Setup;
+
+final class SetupOnDestructor
+{
+    #[Setup]
+    public function __destruct() {}
+}

--- a/tests/Traits/AttributeReader/SetupAttribute/SetupAttributeTest.php
+++ b/tests/Traits/AttributeReader/SetupAttribute/SetupAttributeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Traits\AttributeReader\SetupAttribute;
+
+use Generator;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use Kaspi\DiContainer\Traits\AttributeReaderTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Tests\Traits\AttributeReader\SetupAttribute\Fixtures\SetupImmutableOnConstructor;
+use Tests\Traits\AttributeReader\SetupAttribute\Fixtures\SetupImmutableOnDestructor;
+use Tests\Traits\AttributeReader\SetupAttribute\Fixtures\SetupOnConstructor;
+use Tests\Traits\AttributeReader\SetupAttribute\Fixtures\SetupOnDestructor;
+
+/**
+ * @covers \Kaspi\DiContainer\Attributes\Setup
+ * @covers \Kaspi\DiContainer\Attributes\SetupImmutable
+ * @covers \Kaspi\DiContainer\Traits\AttributeReaderTrait
+ *
+ * @internal
+ */
+class SetupAttributeTest extends TestCase
+{
+    protected object $reader;
+
+    public function setUp(): void
+    {
+        $this->reader = new class {
+            use AttributeReaderTrait {
+                getSetupAttribute as public;
+            }
+        };
+    }
+
+    public function dataProviderFailSetups(): Generator
+    {
+        yield 'on construct #Setup' => [SetupOnConstructor::class, '::__construct()'];
+
+        yield 'on construct #SetupImmutable' => [SetupImmutableOnConstructor::class, '::__construct()'];
+
+        yield 'on destructor #Setup' => [SetupOnDestructor::class, '::__destruct()'];
+
+        yield 'on destructor #SetupImmutable' => [SetupImmutableOnDestructor::class, '::__destruct()'];
+    }
+
+    /**
+     * @dataProvider dataProviderFailSetups
+     */
+    public function testReadSetupAttributeOnConstructor(string $class, string $method): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/Cannot use attribute.+'.$method.'/');
+
+        $this->reader->getSetupAttribute(new ReflectionClass($class))->valid();
+    }
+}

--- a/tests/Traits/ParametersResolver/DeprecatedMethodAddArgumentTest.php
+++ b/tests/Traits/ParametersResolver/DeprecatedMethodAddArgumentTest.php
@@ -43,7 +43,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
 
         $this->addArgument('iterator', []);
 
-        $this->assertEquals([], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals([], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testAddArgumentVariadicSuccess(): void
@@ -56,7 +56,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
 
         $this->addArgument('iterator', [[], []]);
 
-        $this->assertEquals([[], []], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals([[], []], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testAddArgumentFailByName(): void
@@ -72,7 +72,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessage('Invalid input argument name "a"');
 
-        $this->resolveParameters($this->getBindArguments(), $reflectionParameters);
+        $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false);
     }
 
     public function testAddArgumentFailByCount(): void
@@ -88,7 +88,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessage('Too many input arguments');
 
-        $this->resolveParameters($this->getBindArguments(), $reflectionParameters);
+        $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false);
     }
 
     public function testAddArgumentsWithoutNames(): void
@@ -107,7 +107,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
             diAutowire(SuperClass::class), // 🚩 without array key as argument name
         ]);
 
-        $this->assertEquals('ok', call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals('ok', call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testAddArgumentByIndex(): void
@@ -124,7 +124,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
         $this->addArgument(0, 'value');
         $this->addArgument(1, diAutowire(SuperClass::class));
 
-        $this->assertEquals('ok', call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals('ok', call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testAddArgumentsSuccess(): void
@@ -143,7 +143,7 @@ class DeprecatedMethodAddArgumentTest extends TestCase
             'iterator' => ['ok'],
         ]);
 
-        $this->assertEquals(['ok', null], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals(['ok', null], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testNoUserDefinedArgumentSuccess(): void
@@ -160,6 +160,6 @@ class DeprecatedMethodAddArgumentTest extends TestCase
 
         $this->addArguments([])->getBindArguments();
 
-        $this->assertEquals(['app'], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $this->assertEquals(['app'], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveByInjectAttributeTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByInjectAttributeTest.php
@@ -60,7 +60,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters);
+        $params = $this->resolveParameters([], $reflectionParameters, true);
         $this->assertEquals(
             ['✔', '❤'],
             call_user_func_array($fn, $params)->getArrayCopy()
@@ -88,7 +88,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
         $this->expectException(AutowireAttributeException::class);
         $this->expectExceptionMessage('once per non-variadic parameter');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 
     public function testParameterResolveTypedVariadicArgumentByTowInjectAttributeWithId(): void
@@ -103,14 +103,10 @@ class ParameterResolveByInjectAttributeTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects($this->atLeast(2))
             ->method('get')
-            ->with($this->logicalOr(
-                'services.one',
-                'services.tow',
-            ))
-            ->willReturn(
-                new SuperClass(),
-                new MoreSuperClass(),
-            )
+            ->willReturnMap([
+                ['services.one', new SuperClass()],
+                ['services.tow', new MoreSuperClass()],
+            ])
         ;
         $mockContainer->method('getConfig')
             ->willReturn(new DiContainerConfig(useAttribute: true))
@@ -118,7 +114,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertIsArray($res);
         $this->assertInstanceOf(SuperInterface::class, $res[0]);
@@ -145,7 +141,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertIsArray($res);
         $this->assertInstanceOf(SuperInterface::class, $res[0]);
@@ -171,7 +167,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertIsObject($res);
     }
@@ -199,7 +195,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessageMatches('/Unresolvable dependency.+object\|string \$parameter.+Not found/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 
     public function testParameterResolveByArgumentNameNotFoundWithDefaultValue(): void
@@ -222,7 +218,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertEquals('welcome!', $res);
     }
@@ -247,7 +243,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertEquals(['Ivan', 'Piter'], $res);
     }
@@ -276,7 +272,7 @@ class ParameterResolveByInjectAttributeTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertCount(1, $res);
 

--- a/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
@@ -62,14 +62,10 @@ class ParameterResolveByTaggedAsTest extends TestCase
         ;
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                ClassWithDependency::class,
-                MoreSuperClass::class,
-            ))
-            ->willReturn(
-                new ClassWithDependency('ok'),
-                new MoreSuperClass(),
-            )
+            ->willReturnMap([
+                [ClassWithDependency::class, new ClassWithDependency('ok')],
+                [MoreSuperClass::class, new MoreSuperClass()],
+            ])
         ;
         $mockContainer
             ->method('getConfig')
@@ -78,7 +74,7 @@ class ParameterResolveByTaggedAsTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertTrue($res->valid());
         $this->assertInstanceOf(ClassWithDependency::class, $res->current());
@@ -116,16 +112,11 @@ class ParameterResolveByTaggedAsTest extends TestCase
         ;
         $mockContainer->expects(self::exactly(3))
             ->method('get')
-            ->with(self::logicalOr(
-                ClassWithDependency::class,
-                MoreSuperClass::class,
-                SuperClass::class,
-            ))
-            ->willReturn(
-                new ClassWithDependency('ok'),
-                new MoreSuperClass(),
-                new SuperClass(),
-            )
+            ->willReturnMap([
+                [ClassWithDependency::class, new ClassWithDependency('ok')],
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+            ])
         ;
         $mockContainer
             ->method('getConfig')
@@ -134,7 +125,7 @@ class ParameterResolveByTaggedAsTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertTrue($res1->valid());
         $this->assertInstanceOf(ClassWithDependency::class, $res1->current());
@@ -171,14 +162,10 @@ class ParameterResolveByTaggedAsTest extends TestCase
         ;
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                ClassWithDependency::class,
-                MoreSuperClass::class,
-            ))
-            ->willReturn(
-                new ClassWithDependency('ok'),
-                new MoreSuperClass(),
-            )
+            ->willReturnMap([
+                [ClassWithDependency::class, new ClassWithDependency('ok')],
+                [MoreSuperClass::class, new MoreSuperClass()],
+            ])
         ;
         $mockContainer
             ->method('getConfig')
@@ -187,7 +174,7 @@ class ParameterResolveByTaggedAsTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertTrue($res->valid());
         $this->assertInstanceOf(ClassWithDependency::class, $res->current());
@@ -222,16 +209,11 @@ class ParameterResolveByTaggedAsTest extends TestCase
         ;
         $mockContainer->expects(self::exactly(3))
             ->method('get')
-            ->with(self::logicalOr(
-                ClassWithDependency::class,
-                MoreSuperClass::class,
-                SuperClass::class,
-            ))
-            ->willReturn(
-                new ClassWithDependency('ok'),
-                new MoreSuperClass(),
-                new SuperClass(),
-            )
+            ->willReturnMap([
+                [ClassWithDependency::class, new ClassWithDependency('ok')],
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+            ])
         ;
         $mockContainer
             ->method('getConfig')
@@ -240,7 +222,7 @@ class ParameterResolveByTaggedAsTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertTrue($res1->valid());
         $this->assertInstanceOf(ClassWithDependency::class, $res1->current());

--- a/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
@@ -45,7 +45,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->assertInstanceOf(
             ArrayIterator::class,
-            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters))
+            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, false))
         );
     }
 
@@ -63,7 +63,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->assertInstanceOf(
             ArrayIterator::class,
-            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters))
+            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, false))
         );
     }
 
@@ -76,19 +76,15 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         $mockContainer
             ->expects(self::exactly(2))
             ->method('get')
-            ->with($this->logicalOr(
-                SuperClass::class,
-                'word'
-            ))
-            ->willReturn(
-                new SuperClass(),
-                'one'
-            )
+            ->willReturnMap([
+                [SuperClass::class, new SuperClass()],
+                ['word', 'one'],
+            ])
         ;
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters);
+        $params = $this->resolveParameters([], $reflectionParameters, false);
 
         $this->assertCount(2, $params);
         $this->assertInstanceOf(SuperClass::class, $params[0]);
@@ -115,7 +111,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters);
+        $params = $this->resolveParameters([], $reflectionParameters, false);
 
         $this->assertCount(1, $params);
         $this->assertEquals(
@@ -141,7 +137,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters);
+        $params = $this->resolveParameters([], $reflectionParameters, false);
 
         $this->assertEquals(
             ['one', 'two', 'three'],
@@ -161,7 +157,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         ;
         $this->setContainer($mockContainer);
 
-        $this->assertNull(call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters)));
+        $this->assertNull(call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, false)));
     }
 
     public function testParameterResolveByTypeWithVariadic(): void
@@ -177,7 +173,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         $this->setContainer($mockContainer);
         $this->assertInstanceOf(
             ArrayIterator::class,
-            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters))[0]
+            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, false))[0]
         );
     }
 
@@ -197,7 +193,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessageMatches('/Unresolvable dependency.+SuperClass \$superClass.+Not found/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, false);
     }
 
     public function testParameterResolveByTypeThrowWhenResolveDependency(): void
@@ -216,6 +212,6 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Unresolvable dependency.+SuperClass \$superClass.+some error/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, false);
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
@@ -52,7 +52,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
                 ->bindArguments(dependency: 'aaaa')
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(ClassWithDependency::class, $res);
     }
@@ -71,7 +71,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
                 ->bindArguments('aaaa')
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(ClassWithDependency::class, $res);
     }
@@ -98,7 +98,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
             ]
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
         $this->assertInstanceOf(SuperClass::class, $res[0]);
@@ -107,7 +107,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         // none-singleton
         $this->assertNotSame(
             $res[0],
-            call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters))[0]
+            call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false))[0]
         );
     }
 
@@ -127,7 +127,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
             ]
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(SuperClass::class, $res[0]);
         $this->assertInstanceOf(MoreSuperClass::class, $res[1]);
@@ -149,7 +149,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
             ]
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
         $this->assertInstanceOf(SuperClass::class, $res[0]);
@@ -158,7 +158,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         // is singleton
         $this->assertSame(
             $res[0],
-            call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters))[0]
+            call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false))[0]
         );
     }
 
@@ -170,14 +170,10 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                'services.super.one',
-                'services.super.two'
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass(),
-            )
+            ->willReturnMap([
+                ['services.super.one', new MoreSuperClass()],
+                ['services.super.two', new SuperClass()],
+            ])
         ;
         $this->setContainer($mockContainer);
 
@@ -189,7 +185,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
             ]
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
         $this->assertInstanceOf(MoreSuperClass::class, $res[0]);
@@ -204,14 +200,10 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                'services.super.one',
-                'services.super.two',
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass(),
-            )
+            ->willReturnMap([
+                ['services.super.one', new MoreSuperClass()],
+                ['services.super.two', new SuperClass()],
+            ])
         ;
         $this->setContainer($mockContainer);
 
@@ -221,7 +213,7 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
             diGet('services.super.two')
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertCount(2, $res);
         $this->assertInstanceOf(MoreSuperClass::class, $res[0]);

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
@@ -48,7 +48,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
             iterator: diGet('services.icon-iterator'),
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(ArrayIterator::class, $res);
         $this->assertEquals(['🚀', '🔥'], $res->getArrayCopy());
@@ -60,29 +60,24 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
 
         $mockContainer = $this->createMock(DiContainerInterface::class);
-        $mockContainer->expects(self::exactly(2))
-            ->method('get')
-            ->with($this->logicalOr(
-                'services.icon-iterator.one',
-                'services.icon-iterator.two'
-            ))
-            ->willReturn(
-                new ArrayIterator(array: ['🚀']),
-                new ArrayIterator(array: ['🔥']),
-            )
+        $mockContainer->method('get')
+            ->willReturnMap([
+                ['services.icon-iterator.one', new ArrayIterator(array: ['🚀'])],
+                ['services.icon-iterator.two', new ArrayIterator(array: ['🔥'])],
+            ])
         ;
 
         $this->setContainer($mockContainer);
         // 🚩 test data
         $this->bindArguments(
             iterator: [
-                diGet('services.icon-iterator.two'),
                 diGet('services.icon-iterator.one'),
+                diGet('services.icon-iterator.two'),
             ],
             name: 'Piter'
         );
 
-        [$name, $res] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$name, $res] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals('Piter', $name);
         $this->assertCount(2, $res);
@@ -102,25 +97,21 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                'services.icon-iterator.two',
-                'services.icon-iterator.one'
-            ))
-            ->willReturn(
-                new ArrayIterator(array: ['🚀']),
-                new ArrayIterator(array: ['🔥']),
-            )
+            ->willReturnMap([
+                ['services.icon-iterator.one', new ArrayIterator(array: ['🚀'])],
+                ['services.icon-iterator.two', new ArrayIterator(array: ['🔥'])],
+            ])
         ;
 
         $this->setContainer($mockContainer);
         // 🚩 test data
         $this->bindArguments(
             'Ivan',
-            diGet('services.icon-iterator.two'),
             diGet('services.icon-iterator.one'),
+            diGet('services.icon-iterator.two'),
         );
 
-        [$name, $res] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$name, $res] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals('Ivan', $name);
         $this->assertCount(2, $res);
@@ -140,14 +131,10 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                'services.icon-iterator.one',
-                'services.icon-iterator.two'
-            ))
-            ->willReturn(
-                new ArrayIterator(array: ['🚀']),
-                new ArrayIterator(array: ['🔥']),
-            )
+            ->willReturnMap([
+                ['services.icon-iterator.one', new ArrayIterator(array: ['🚀'])],
+                ['services.icon-iterator.two', new ArrayIterator(array: ['🔥'])],
+            ])
         ;
 
         $this->setContainer($mockContainer);
@@ -157,7 +144,7 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
             diGet('services.icon-iterator.two')
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
 

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
@@ -45,7 +45,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data
         $this->bindArguments(['aaa', 'bbb', 'ccc']);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals(['aaa', 'bbb', 'ccc'], $res);
     }
@@ -62,7 +62,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data
         $this->bindArguments(iterator: ['aaa', 'bbb', 'ccc']);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals(['aaa', 'bbb', 'ccc'], $res);
     }
@@ -83,7 +83,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
             ['ddd', 'eee', 'fff'],
         );
 
-        [$str ,$iter] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$str ,$iter] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals('my way', $str);
         $this->assertCount(2, $iter);
@@ -106,7 +106,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
             ['ddd', 'eee', 'fff'],
         ]);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
 
@@ -126,7 +126,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data
         $this->bindArguments(iterator: diValue(['aaa', 'bbb', 'ccc']));
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(1, $res);
 
@@ -145,7 +145,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data
         $this->bindArguments('aaa', 'bbb', 'ccc');
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(3, $res);
 
@@ -166,7 +166,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data, unsorted parameter names
         $this->bindArguments(word: ['aaa', 'bbb', 'ccc'], numbers: [1_000, 10_000]);
 
-        [$numbers, $word] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$numbers, $word] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $numbers);
         $this->assertEquals(1_000, $numbers[0]);
@@ -194,7 +194,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         // 🚩 test data
         $this->bindArguments('Hello', numbers: [1_000, 10_000]);
 
-        [$str, $super, $numbers] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$str, $super, $numbers] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals('Hello', $str);
         $this->assertEquals([1000, 10000], $numbers);

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest.php
@@ -49,7 +49,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
         // 🚩 test data
         $this->bindArguments(iterator: ['aaa', 'bbb', 'ccc']);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertEquals(['aaa', 'bbb', 'ccc'], $res);
     }
@@ -71,7 +71,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
             ]
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertCount(2, $res);
 
@@ -93,7 +93,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
             str: 'hi my darling'
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(1, $res);
 
@@ -115,7 +115,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
             ['ddd', 'eee', 'fff'],
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
 
@@ -137,7 +137,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
         ;
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertCount(3, $res);
         $this->assertEquals(['hello', 'world', '!'], $res);
@@ -157,7 +157,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
         ;
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertCount(3, $res);
         $this->assertEquals(['hello', 'world', '!'], $res);

--- a/tests/Traits/ParametersResolver/ParameterResolveFailByAttributesTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveFailByAttributesTest.php
@@ -63,7 +63,7 @@ class ParameterResolveFailByAttributesTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Only one of the attributes.+may be declared/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 
     public function testCannotUseAttributeTaggedAsAndInjectTogether(): void
@@ -80,7 +80,7 @@ class ParameterResolveFailByAttributesTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Only one of the attributes.+may be declared/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 
     public function testCannotUseAttributeTaggedAsAndInjectAndProxyClosureTogether(): void
@@ -99,7 +99,7 @@ class ParameterResolveFailByAttributesTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Only one of the attributes.+may be declared/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 
     public function testCannotUseAttributeInjectAndInjectCallableTogether(): void
@@ -116,6 +116,6 @@ class ParameterResolveFailByAttributesTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Only one of the attributes.+may be declared/');
 
-        $this->resolveParameters([], $reflectionParameters);
+        $this->resolveParameters([], $reflectionParameters, true);
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest.php
@@ -60,10 +60,10 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertInstanceOf(Closure::class, $res);
-        $this->assertNotSame($res, call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters)));
+        $this->assertNotSame($res, call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true)));
         $this->assertInstanceOf(MoreSuperClass::class, $res());
     }
 
@@ -93,9 +93,9 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
 
         $this->setContainer($mockContainer);
 
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
-        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters)));
+        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true)));
     }
 
     public function testResolveArgumentVariadicByAttribute(): void
@@ -110,25 +110,17 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('has')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                true,
-                true
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, true],
+                [SuperClass::class, true],
+            ])
         ;
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass()
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+            ])
         ;
         $mockContainer->method('getConfig')
             ->willReturn(new DiContainerConfig())
@@ -136,7 +128,7 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
 
         $this->setContainer($mockContainer);
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertInstanceOf(Closure::class, $res1);
         $this->assertInstanceOf(Closure::class, $res2);
@@ -155,21 +147,16 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
 
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->method('has')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(true)
+            ->willReturnMap([
+                [MoreSuperClass::class, true],
+                [SuperClass::class, true],
+            ])
         ;
         $mockContainer->method('get')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass()
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+            ])
         ;
         $mockContainer->method('getConfig')
             ->willReturn(
@@ -179,8 +166,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
 
         $this->setContainer($mockContainer);
 
-        [$res11, $res12] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
-        [$res21, $res22] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters));
+        [$res11, $res12] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
+        [$res21, $res22] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
 
         $this->assertNotSame($res11, $res21);
         $this->assertSame($res12, $res22);

--- a/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
@@ -57,7 +57,7 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             item: diProxyClosure(MoreSuperClass::class),
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(Closure::class, $res);
         $this->assertInstanceOf(MoreSuperClass::class, $res());
@@ -85,8 +85,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             item: diProxyClosure(MoreSuperClass::class, true),
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
-        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testResolveArgumentNoneVariadicByNameIsNoneSingleton(): void
@@ -111,8 +111,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             item: diProxyClosure(MoreSuperClass::class, false),
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
-        $this->assertNotSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters)));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        $this->assertNotSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testResolveArgumentNoneVariadicByIndex(): void
@@ -139,7 +139,7 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             diProxyClosure(MoreSuperClass::class),
         );
 
-        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(Closure::class, $res);
         $this->assertInstanceOf(MoreSuperClass::class, $res());
@@ -153,25 +153,17 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('has')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                true,
-                true
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, true],
+                [SuperClass::class, true],
+            ])
         ;
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass()
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+            ])
         ;
 
         $this->setContainer($mockContainer);
@@ -184,7 +176,7 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             ]
         );
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(Closure::class, $res1);
         $this->assertInstanceOf(Closure::class, $res2);
@@ -198,24 +190,17 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
 
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->method('has')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                true
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, true],
+                [SuperClass::class, true],
+            ])
         ;
         $mockContainer->method('get')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                new MoreSuperClass(),
-                new SuperClass(),
-                new MoreSuperClass(),
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, new MoreSuperClass()],
+                [SuperClass::class, new SuperClass()],
+                [MoreSuperClass::class, new MoreSuperClass()],
+            ])
         ;
 
         $this->setContainer($mockContainer);
@@ -230,8 +215,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             ]
         );
 
-        [$res11, $res12, $res13] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
-        [$res21, $res22, $res23] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$res11, $res12, $res13] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        [$res21, $res22, $res23] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertNotSame($res11, $res13);
         $this->assertNotSame($res21, $res23);
@@ -247,25 +232,17 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
         $mockContainer->expects(self::exactly(2))
             ->method('has')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                true,
-                true
-            )
+            ->willReturnMap([
+                [MoreSuperClass::class, true],
+                [SuperClass::class, true],
+            ])
         ;
         $mockContainer->expects(self::exactly(2))
             ->method('get')
-            ->with(self::logicalOr(
-                MoreSuperClass::class,
-                SuperClass::class
-            ))
-            ->willReturn(
-                new SuperClass(),
-                new MoreSuperClass(),
-            )
+            ->willReturnMap([
+                [SuperClass::class, new SuperClass()],
+                [MoreSuperClass::class, new MoreSuperClass()],
+            ])
         ;
 
         $this->setContainer($mockContainer);
@@ -276,7 +253,7 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
             diProxyClosure(MoreSuperClass::class),
         );
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters));
+        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(Closure::class, $res1);
         $this->assertInstanceOf(Closure::class, $res2);

--- a/tests/Traits/ParametersResolver/ParameterUnionTypeTest.php
+++ b/tests/Traits/ParametersResolver/ParameterUnionTypeTest.php
@@ -59,7 +59,7 @@ class ParameterUnionTypeTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Cannot automatically resolve dependency.+"\$type".+One.+Two/');
 
-        $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters());
+        $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters(), false);
     }
 
     public function testUnionTypeByPhpDefinitionSuccess(): void
@@ -75,7 +75,8 @@ class ParameterUnionTypeTest extends TestCase
 
         $res = $this->resolveParameters(
             [diGet(Two::class)],
-            (new ReflectionFunction($fn))->getParameters()
+            (new ReflectionFunction($fn))->getParameters(),
+            false
         );
 
         $this->assertInstanceOf(Two::class, call_user_func_array($fn, $res));
@@ -97,7 +98,7 @@ class ParameterUnionTypeTest extends TestCase
         $this->expectException(AutowireExceptionInterface::class);
         $this->expectExceptionMessageMatches('/Cannot automatically resolve dependency.+"\$type".+One.+Two/');
 
-        $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters());
+        $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters(), false);
     }
 
     public function testUnionTypeByPhpAttributeSuccess(): void
@@ -117,7 +118,7 @@ class ParameterUnionTypeTest extends TestCase
 
         $this->setContainer($this->mockContainer);
 
-        $res = $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters());
+        $res = $this->resolveParameters([], (new ReflectionFunction($fn))->getParameters(), false);
 
         $this->assertInstanceOf(Two::class, call_user_func_array($fn, $res));
     }


### PR DESCRIPTION
* feat: [DiDefinitionConfigAutowireInterface] Add method for setup immutable service.

* feat: [DiDefinitionAutowire] Implement method `DiDefinitionAutowire::setupImmutable`.

* feat: [Setup, SetupImmutable] Php attributes for setters.

* feat: [DiDefinitionAutowire] String argument for `Setup` and `SetupImmutable` attribute with the speciational symbol "@" as link to other container identifier.

* fix: [DiDefinitionAutowireTrait, DiAutowireTrait] Fix type-hint for the parameter `?ReflectionType $returnType` in method `DiAutowireTrait::diffReturnType()`

* dev: [Tests] Update tests.

* dev: [DiDefinitionConfigAutowireInterface] Update phpdoc block.

* dev: [ParametersResolverTrait] Required argument `$isAttributeOnParamHigherPriority` on `ParametersResolverTrait::resolveParameters()`

* dev: [DiDefinitionAutowire, TagsTrait] Refactoring "tags" - using php attribute `#[Tag] and php definition via `bingTag`.