### PR TITLE
fix: [ParametersResolverTrait] Skip resolving variadic parameter.

### DIFF
--- a/src/DiContainer/Traits/ParametersResolverTrait.php
+++ b/src/DiContainer/Traits/ParametersResolverTrait.php
@@ -132,6 +132,10 @@ trait ParametersResolverTrait
                     continue;
                 }
 
+                if ($parameter->isVariadic()) {
+                    continue;
+                }
+
                 $strType = $this->getParameterType($parameter, $this->getContainer());
 
                 $dependencies[] = null === $strType

--- a/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
+++ b/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
@@ -151,7 +151,7 @@ class CallClassDefinitionVariadicArgTest extends TestCase
         $this->assertInstanceOf(WordHello::class, $res[1]);
     }
 
-    public function testCallStaticMethodResolveByArgumentName(): void
+    public function testCallStaticMethodResolveWithoutArguments(): void
     {
         $config = new DiContainerConfig();
         $definitions = [
@@ -161,7 +161,6 @@ class CallClassDefinitionVariadicArgTest extends TestCase
 
         $res = $container->call([Talk::class, 'staticMethodByArgumentNameOneToMany']);
 
-        $this->assertCount(1, $res);
-        $this->assertInstanceOf(WordSuffix::class, $res[0]);
+        self::assertEmpty($res);
     }
 }

--- a/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
+++ b/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
@@ -11,6 +11,7 @@ use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleA;
 use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleB;
 use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleC;
 use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleGenerator;
+use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleInterface;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diGet;
@@ -26,6 +27,7 @@ use function Kaspi\DiContainer\diValue;
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
  * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\diValue
+ * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait::getParameterType
  *
  * @internal
  */
@@ -100,5 +102,17 @@ class VariadicArgumentTest extends TestCase
 
         $this->assertEquals(['first'], $container->get(ParameterIterableVariadic::class)->getParameters()[0]);
         $this->assertEquals(['second'], $container->get(ParameterIterableVariadic::class)->getParameters()[1]);
+    }
+
+    public function testVariadicParameterWithoutBindArguments(): void
+    {
+        $container = (new DiContainerFactory())->make([
+            diAutowire(RuleGenerator::class),
+            RuleInterface::class => diAutowire(RuleA::class),
+        ]);
+
+        $ruleGenerator = $container->get(RuleGenerator::class);
+
+        self::assertEmpty($ruleGenerator->getRules());
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
@@ -16,8 +16,11 @@ use ReflectionFunction;
 use Tests\Traits\ParametersResolver\Fixtures\SuperClass;
 
 use function call_user_func_array;
+use function Kaspi\DiContainer\diGet;
 
 /**
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet::getDefinition
+ * @covers \Kaspi\DiContainer\diGet
  * @covers \Kaspi\DiContainer\Traits\DiContainerTrait
  * @covers \Kaspi\DiContainer\Traits\ParametersResolverTrait
  * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
@@ -84,7 +87,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters, false);
+        $params = $this->resolveParameters(['word' => diGet('word')], $reflectionParameters, false);
 
         $this->assertCount(2, $params);
         $this->assertInstanceOf(SuperClass::class, $params[0]);
@@ -111,7 +114,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->setContainer($mockContainer);
 
-        $params = $this->resolveParameters([], $reflectionParameters, false);
+        $params = $this->resolveParameters([diGet('phrase')], $reflectionParameters, false);
 
         $this->assertCount(1, $params);
         $this->assertEquals(
@@ -173,7 +176,7 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
         $this->setContainer($mockContainer);
         $this->assertInstanceOf(
             ArrayIterator::class,
-            call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, false))[0]
+            call_user_func_array($fn, $this->resolveParameters([diGet(ArrayIterator::class)], $reflectionParameters, false))[0]
         );
     }
 


### PR DESCRIPTION
Variadic parameter must be set via `bindArguments` or PHP attribute.