### PR TITLE
Drop `$isSingleton` for attribute InjectByCallable, ProxyClosure and definition parameter resolver.

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -171,7 +171,12 @@ diAutowire(...)->bindArguments(var1: 'value 1', var2: 'value 2')
 > Для аргументов не объявленных через `bindArgument` контейнер попытается разрешить зависимости самостоятельно.
 
 > [!TIP]
-> Аргументы `$argument` в `bindArgument` могут принимать хэлпер функции такие как `diGet`, `diValue`, `diAutowire` и другие.
+> Аргумент `$argument` в `bindArgument` может принимать хэлпер функции такие как `diGet`, `diValue`, `diAutowire` и другие.
+>
+> Если в `$argument` присваивается хэлпер функция или объект реализующий интерфейс
+> `Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInvokableInterface::class`
+> (например `Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire::class`)
+> то признак isSingleton будет проигнорирован при разрешении зависимости данного параметра.
 
 **Дополнительная настройка сервиса через методы класса (mutable setters):**
 ```php 
@@ -295,7 +300,7 @@ diCallable(array|callable|string $definition, ?bool $isSingleton = null): DiDefi
 > [!IMPORTANT]
 > Функция `diCallable` возвращает объект реализующий интерфейс `DiDefinitionArgumentsInterface`
 > предоставляющий методы:
-> - `bindArguments` - указать аргументы для определения
+> - `bindArguments` - указать аргументы для параметров функции.
 > - `bindTag` - добавляет тег с мета-данными для определения.
 
 **Аргументы для определения:**
@@ -308,7 +313,13 @@ bindArguments(mixed ...$argument)`
  // function(string $var1, string $var2) 
  ```
 > [!TIP]
-> Аргументы `$argument` в `bindArgument` могут принимать хэлпер функции такие как `diGet`, `diValue`, `diAutowire` и другие.
+> Аргумент `$argument` в `bindArgument` может принимать хэлпер функции такие как `diGet`, `diValue`, `diAutowire` и другие.
+>
+> Если в `$argument` присваивается хэлпер функция или объект реализующий интерфейс
+> `Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInvokableInterface::class`
+> (например `Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire::class`)
+> то признак isSingleton будет проигнорирован при разрешении зависимости данного параметра.
+
 
 > [!WARNING]
 > метод `bindArguments` перезаписывает ранее определенные аргументы.

--- a/docs/02-attribute-definition.md
+++ b/docs/02-attribute-definition.md
@@ -691,15 +691,14 @@ var_dump($ruleGenerator->inputRule instanceof App\Rules\RuleA); // true
 
 ## InjectByCallable
 
-Применяется к аргументам конструктора класса, метода или функции через [`callable` тип](https://github.com/agdobrynin/di-container/blob/main/docs/03-call-method.md#поддерживаемые-типы)
+Применяется к параметрам конструктора класса, метода или функции через [`callable` тип](https://github.com/agdobrynin/di-container/blob/main/docs/03-call-method.md#поддерживаемые-типы)
 на основе [вызова `DiContainer::call()`](https://github.com/agdobrynin/di-container/blob/main/docs/03-call-method.md).
 
 ```php
-#[InjectByCallable(string $callable, ?bool $isSingleton = null)]
+#[InjectByCallable(string $callable)]
 ```
 Аргументы:
 - `$callable` - строка которая может быть преобразована к `callable` для получения результата внедрения.
-- `$isSingleton` - зарегистрировать как singleton сервис. Если значение `null` то значение будет выбрано на основе [настройки контейнера](https://github.com/agdobrynin/di-container/tree/main?tab=readme-ov-file#%D0%BA%D0%BE%D0%BD%D1%84%D0%B8%D0%B3%D1%83%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-dicontainer).
 
 > [!TIP]
 > Аргументы указанные в `callable` вызове могут быть разрешены
@@ -948,13 +947,13 @@ print $myClass->age; // 22
 ## ProxyClosure
 
 Реализация ленивой инициализации параметров класса (зависимости) через функцию обратного вызова.
+Применяется к параметрам конструктора класса, метода или функции.
 
 ```php
-#[ProxyClosure(string $id, ?bool $isSingleton = null)]
+#[ProxyClosure(string $id)]
 ```
 Аргументы:
 - `$id` - класс (_FQCN_) реализующий сервис который необходимо разрешить отложено.
-- `$isSingleton` - зарегистрировать как singleton сервис. Если значение `null` то значение будет выбрано на основе [настройки контейнера](https://github.com/agdobrynin/di-container/tree/main?tab=readme-ov-file#%D0%BA%D0%BE%D0%BD%D1%84%D0%B8%D0%B3%D1%83%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-dicontainer).
 
 Такое объявление сервиса пригодится для «тяжёлых» зависимостей, требующих длительного времени инициализации или ресурсоёмких вычислений.
 
@@ -1068,6 +1067,7 @@ class SomeClass {}
 
 ## TaggedAs
 Получение коллекции (_списка_) сервисов и определений отмеченных тегом.
+Применяется к параметрам конструктора класса, метода или функции.
 Тегирование класса в стиле php определенй через метод `bindTag` у [хэлпер функций](https://github.com/agdobrynin/di-container/blob/main/docs/01-php-definition.md#%D0%BE%D0%B1%D1%8A%D1%8F%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F-%D1%87%D0%B5%D1%80%D0%B5%D0%B7-%D1%85%D1%8D%D0%BB%D0%BF%D0%B5%D1%80-%D1%84%D1%83%D0%BD%D0%BA%D1%86%D0%B8%D0%B8)
 или через [php атрибут `#[Tag]`](#tag) у тегированного класса.
 

--- a/src/DiContainer/Attributes/InjectByCallable.php
+++ b/src/DiContainer/Attributes/InjectByCallable.php
@@ -17,7 +17,7 @@ final class InjectByCallable implements DiAttributeInterface
     /**
      * @param non-empty-string $callable
      */
-    public function __construct(private string $callable, private ?bool $isSingleton = null)
+    public function __construct(private string $callable)
     {
         if ('' === $callable || str_contains($callable, ' ')) { // @phpstan-ignore identical.alwaysFalse
             throw new AutowireAttributeException(
@@ -32,10 +32,5 @@ final class InjectByCallable implements DiAttributeInterface
     public function getIdentifier(): string
     {
         return $this->callable;
-    }
-
-    public function isSingleton(): ?bool
-    {
-        return $this->isSingleton;
     }
 }

--- a/src/DiContainer/Attributes/ProxyClosure.php
+++ b/src/DiContainer/Attributes/ProxyClosure.php
@@ -6,17 +6,17 @@ namespace Kaspi\DiContainer\Attributes;
 
 use Attribute;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
-use Kaspi\DiContainer\Interfaces\Attributes\DiAttributeServiceInterface;
+use Kaspi\DiContainer\Interfaces\Attributes\DiAttributeInterface;
 
 use function trim;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
-final class ProxyClosure implements DiAttributeServiceInterface
+final class ProxyClosure implements DiAttributeInterface
 {
     /**
      * @param class-string|non-empty-string $id class name or container identifier
      */
-    public function __construct(private string $id, private ?bool $isSingleton = null)
+    public function __construct(private string $id)
     {
         if ('' === trim($id)) {
             throw new AutowireAttributeException('The $id parameter must be a non-empty string.');
@@ -29,10 +29,5 @@ final class ProxyClosure implements DiAttributeServiceInterface
     public function getIdentifier(): string
     {
         return $this->id;
-    }
-
-    public function isSingleton(): ?bool
-    {
-        return $this->isSingleton;
     }
 }

--- a/tests/Attributes/Raw/InjectByCallableTest.php
+++ b/tests/Attributes/Raw/InjectByCallableTest.php
@@ -8,6 +8,7 @@ use Generator;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use PHPUnit\Framework\TestCase;
+use Tests\Attributes\Raw\Fixtures\MyDiFactory;
 
 /**
  * @covers \Kaspi\DiContainer\Attributes\InjectByCallable
@@ -18,24 +19,19 @@ class InjectByCallableTest extends TestCase
 {
     public function successIdsDataProvider(): Generator
     {
-        yield 'string' => ['ok', null, 'ok', null];
+        yield 'string' => ['ok', 'ok'];
 
-        yield 'string with singleton false' => ['ok', false, 'ok', false];
-
-        yield 'string aka static method' => ['MyClass::ok', true, 'MyClass::ok', true];
+        yield 'string invoke method' => [MyDiFactory::class, 'Tests\Attributes\Raw\Fixtures\MyDiFactory'];
     }
 
     /**
      * @dataProvider successIdsDataProvider
      */
-    public function testSuccess(string $id, ?bool $isSingleton, string $expectIdentifier, ?bool $expectIsSingleton): void
+    public function testSuccess(string $id, string $expectIdentifier): void
     {
-        $attr = null === $isSingleton
-            ? new InjectByCallable($id)
-            : new InjectByCallable($id, $isSingleton);
+        $attr = new InjectByCallable($id);
 
         $this->assertEquals($expectIdentifier, $attr->getIdentifier());
-        $this->assertEquals($expectIsSingleton, $attr->isSingleton());
     }
 
     public function failIdsDataProvider(): Generator

--- a/tests/Attributes/Raw/ProxyClosureTest.php
+++ b/tests/Attributes/Raw/ProxyClosureTest.php
@@ -52,14 +52,4 @@ class ProxyClosureTest extends TestCase
 
         new ProxyClosure($id);
     }
-
-    public function testIsSingletonDefault(): void
-    {
-        $this->assertNull((new ProxyClosure('ok'))->isSingleton());
-    }
-
-    public function testIsSingletonTrue(): void
-    {
-        $this->assertTrue((new ProxyClosure('ok', true))->isSingleton());
-    }
 }

--- a/tests/Traits/AttributeReader/InjectCallable/InjectCallableTest.php
+++ b/tests/Traits/AttributeReader/InjectCallable/InjectCallableTest.php
@@ -75,8 +75,8 @@ class InjectCallableTest extends TestCase
     {
         $f = static fn (
             #[InjectByCallable('func1')]
-            #[InjectByCallable('func2', isSingleton: true)]
-            #[InjectByCallable('func3', isSingleton: false)]
+            #[InjectByCallable('func2')]
+            #[InjectByCallable('func3')]
             string ...$a
         ) => '';
         $p = new ReflectionParameter($f, 0);
@@ -87,19 +87,16 @@ class InjectCallableTest extends TestCase
 
         $this->assertInstanceOf(InjectByCallable::class, $injects->current());
         $this->assertEquals('func1', $injects->current()->getIdentifier());
-        $this->assertNull($injects->current()->isSingleton());
 
         $injects->next();
 
         $this->assertInstanceOf(InjectByCallable::class, $injects->current());
         $this->assertEquals('func2', $injects->current()->getIdentifier());
-        $this->assertTrue($injects->current()->isSingleton());
 
         $injects->next();
 
         $this->assertInstanceOf(InjectByCallable::class, $injects->current());
         $this->assertEquals('func3', $injects->current()->getIdentifier());
-        $this->assertFalse($injects->current()->isSingleton());
 
         $injects->next();
 

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
@@ -155,8 +155,8 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         $this->assertInstanceOf(SuperClass::class, $res[0]);
         $this->assertInstanceOf(MoreSuperClass::class, $res[1]);
 
-        // is singleton
-        $this->assertSame(
+        // when bind argument by a definition with $isSingleton — it will be ignored.
+        $this->assertNotSame(
             $res[0],
             call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false))[0]
         );

--- a/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest.php
@@ -67,37 +67,6 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
         $this->assertInstanceOf(MoreSuperClass::class, $res());
     }
 
-    public function testResolveArgumentNoneVariadicAttributeIsSingleton(): void
-    {
-        /**
-         * @param Closure(): MoreSuperClass $item
-         */
-        $fn = static fn (
-            #[ProxyClosure(MoreSuperClass::class, true)]
-            Closure $item
-        ) => $item;
-        $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
-
-        $mockContainer = $this->createMock(DiContainerInterface::class);
-        $mockContainer->method('has')
-            ->with(MoreSuperClass::class)
-            ->willReturn(true)
-        ;
-        $mockContainer->method('get')
-            ->with(MoreSuperClass::class)
-            ->willReturn(new MoreSuperClass())
-        ;
-        $mockContainer->method('getConfig')
-            ->willReturn(new DiContainerConfig())
-        ;
-
-        $this->setContainer($mockContainer);
-
-        $res = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
-
-        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true)));
-    }
-
     public function testResolveArgumentVariadicByAttribute(): void
     {
         $fn = static fn (
@@ -134,42 +103,5 @@ class ParameterResolveUserDefinedArgumentByProxyClosureAttributeTest extends Tes
         $this->assertInstanceOf(Closure::class, $res2);
         $this->assertInstanceOf(MoreSuperClass::class, $res1());
         $this->assertInstanceOf(SuperClass::class, $res2());
-    }
-
-    public function testResolveArgumentVariadicByAttributeIsSingleton(): void
-    {
-        $fn = static fn (
-            #[ProxyClosure(MoreSuperClass::class, false)]
-            #[ProxyClosure(SuperClass::class, true)]
-            Closure ...$item
-        ) => $item;
-        $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
-
-        $mockContainer = $this->createMock(DiContainerInterface::class);
-        $mockContainer->method('has')
-            ->willReturnMap([
-                [MoreSuperClass::class, true],
-                [SuperClass::class, true],
-            ])
-        ;
-        $mockContainer->method('get')
-            ->willReturnMap([
-                [MoreSuperClass::class, new MoreSuperClass()],
-                [SuperClass::class, new SuperClass()],
-            ])
-        ;
-        $mockContainer->method('getConfig')
-            ->willReturn(
-                new DiContainerConfig()
-            )
-        ;
-
-        $this->setContainer($mockContainer);
-
-        [$res11, $res12] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
-        [$res21, $res22] = call_user_func_array($fn, $this->resolveParameters([], $reflectionParameters, true));
-
-        $this->assertNotSame($res11, $res21);
-        $this->assertSame($res12, $res22);
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
@@ -86,7 +86,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
-        $this->assertSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
+        // $isSingleton will be ignored because argument bind through bindArguments()
+        $this->assertNotSame($res, call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testResolveArgumentNoneVariadicByNameIsNoneSingleton(): void
@@ -209,9 +210,9 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
         $this->bindArguments(
             item: [
-                diProxyClosure(MoreSuperClass::class, false), // ➖
-                diProxyClosure(SuperClass::class, true), // ➕
-                diProxyClosure(MoreSuperClass::class, false), // ➖
+                diProxyClosure(MoreSuperClass::class, false),
+                diProxyClosure(SuperClass::class, true),
+                diProxyClosure(MoreSuperClass::class, false),
             ]
         );
 
@@ -221,7 +222,8 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         $this->assertNotSame($res11, $res13);
         $this->assertNotSame($res21, $res23);
         $this->assertNotSame($res11, $res21);
-        $this->assertSame($res12, $res22); // because diProxyClosure(SuperClass::class, true)
+        // because ignore isSingleton diProxyClosure(SuperClass::class, true), ignore in bindArguments()
+        $this->assertNotSame($res12, $res22);
     }
 
     public function testResolveArgumentVariadicByIndex(): void


### PR DESCRIPTION
bc: [InjectByCallable] Drop support parameter `$isSingleton`.

bc: [ProxyClosure] Drop support parameter `$isSingleton`.

bc: [ParametersResolverTrait] Resolving dependency does not support singleton definition.

dev: [Tests] Update tests.

docs: [.md] Update documentation.