### PR TITLE
Bind named argument to variadic parameter

### DIFF
--- a/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
+++ b/tests/DiContainerCall/VariadicArg/CallClassDefinitionVariadicArgTest.php
@@ -41,14 +41,12 @@ class CallClassDefinitionVariadicArgTest extends TestCase
         $res = $container->call(
             [Talk::class, 'staticMethodByReference'],
             [
-                'word' => [ // <- variadic vars wrap by array
-                    diGet(WordSuffix::class),
-                    diGet(WordHello::class),
-                ], // <- variadic vars wrap by array
+                'word' => diGet(WordSuffix::class),
+                'word_2' => diGet(WordHello::class),
             ]
         );
-        $this->assertInstanceOf(WordSuffix::class, $res[0]);
-        $this->assertInstanceOf(WordHello::class, $res[1]);
+        $this->assertInstanceOf(WordSuffix::class, $res['word']);
+        $this->assertInstanceOf(WordHello::class, $res['word_2']);
     }
 
     public function testCallStaticMethodWithoutAttributePassArgumentByDiAutowire(): void
@@ -62,14 +60,12 @@ class CallClassDefinitionVariadicArgTest extends TestCase
         $res = $container->call(
             [Talk::class, 'staticMethodByReference'],
             [
-                'word' => [ // <- variadic vars wrap by array
-                    diAutowire(WordSuffix::class),
-                    diAutowire(WordHello::class),
-                ], // <- variadic vars wrap by array
+                'word' => diAutowire(WordSuffix::class),
+                'word1' => diAutowire(WordHello::class),
             ]
         );
-        $this->assertInstanceOf(WordSuffix::class, $res[0]);
-        $this->assertInstanceOf(WordHello::class, $res[1]);
+        $this->assertInstanceOf(WordSuffix::class, $res['word']);
+        $this->assertInstanceOf(WordHello::class, $res['word1']);
     }
 
     public function testCallStaticMethodWithoutAttributePassArgumentByReferenceOneToMany(): void
@@ -83,14 +79,12 @@ class CallClassDefinitionVariadicArgTest extends TestCase
         $res = $container->call(
             [Talk::class, 'staticMethodByReference'],
             [
-                'word' => [
-                    $container->get(WordSuffix::class),
-                    $container->get(WordHello::class),
-                ],
+                'word' => $container->get(WordSuffix::class),
+                'word2' => $container->get(WordHello::class),
             ]
         );
-        $this->assertInstanceOf(WordSuffix::class, $res[0]);
-        $this->assertInstanceOf(WordHello::class, $res[1]);
+        $this->assertInstanceOf(WordSuffix::class, $res['word']);
+        $this->assertInstanceOf(WordHello::class, $res['word2']);
     }
 
     public function testCallStaticMethodWitAttributeInjectIdAsContainerIdentifier(): void

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
@@ -46,27 +46,27 @@ class TaggedAsThroughContainerVariadicTest extends TestCase
             diAutowire(TwoTwo::class)
                 ->bindTag('tags.two'),
             diAutowire(TaggedVariadicParameters::class)
-                ->bindArguments(variadic: [
-                    diTaggedAs('tags.two'),
-                    diTaggedAs('tags.one'),
-                ]),
+                ->bindArguments(
+                    variadic: diTaggedAs('tags.two'),
+                    variadic2: diTaggedAs('tags.one'),
+                ),
         ]);
 
         $class = $container->get(TaggedVariadicParameters::class);
 
         $this->assertCount(2, $class->variadic);
         // 'tags.two'
-        $this->assertInstanceOf(TwoOne::class, $class->variadic[0]->current());
-        $class->variadic[0]->next();
-        $this->assertInstanceOf(TwoTwo::class, $class->variadic[0]->current());
-        $class->variadic[0]->next();
-        $this->assertFalse($class->variadic[0]->valid());
+        $this->assertInstanceOf(TwoOne::class, $class->variadic['variadic']->current());
+        $class->variadic['variadic']->next();
+        $this->assertInstanceOf(TwoTwo::class, $class->variadic['variadic']->current());
+        $class->variadic['variadic']->next();
+        $this->assertFalse($class->variadic['variadic']->valid());
         // 'tags.one'
-        $this->assertInstanceOf(OneTwo::class, $class->variadic[1]->current()); // priority = 100
-        $class->variadic[1]->next();
-        $this->assertInstanceOf(OneOne::class, $class->variadic[1]->current()); // priority = 0
-        $class->variadic[1]->next();
-        $this->assertFalse($class->variadic[1]->valid());
+        $this->assertInstanceOf(OneTwo::class, $class->variadic['variadic2']->current()); // priority = 100
+        $class->variadic['variadic2']->next();
+        $this->assertInstanceOf(OneOne::class, $class->variadic['variadic2']->current()); // priority = 0
+        $class->variadic['variadic2']->next();
+        $this->assertFalse($class->variadic['variadic2']->valid());
     }
 
     public function testVariadicTaggedByInterfaceWithPhpDefinition(): void
@@ -77,10 +77,10 @@ class TaggedAsThroughContainerVariadicTest extends TestCase
             diAutowire(TwoOne::class),
             diAutowire(TwoTwo::class),
             diAutowire(TaggedVariadicParameters::class)
-                ->bindArguments(variadic: [
+                ->bindArguments(
                     diTaggedAs(OneInterface::class),
                     diTaggedAs(TwoInterface::class),
-                ]),
+                ),
         ]);
 
         $class = $container->get(TaggedVariadicParameters::class);

--- a/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
+++ b/tests/FromDocs/PhpDefinitions/VariadicArgumentTest.php
@@ -15,7 +15,6 @@ use Tests\FromDocs\PhpDefinitions\Fixtures\Variadic\RuleInterface;
 
 use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diGet;
-use function Kaspi\DiContainer\diValue;
 
 /**
  * @covers \Kaspi\DiContainer\diAutowire
@@ -39,12 +38,10 @@ class VariadicArgumentTest extends TestCase
             'ruleC' => diAutowire(RuleC::class),
             diAutowire(RuleGenerator::class)
                 ->bindArguments(
-                    inputRule: // имя аргумента в конструкторе
-                    [ // <-- обернуть параметры в массив для variadic типов если их несколько.
-                        diAutowire(RuleB::class),
-                        diAutowire(RuleA::class),
-                        diGet('ruleC'), // <-- получение по ссылке
-                    ], // <-- обернуть параметры в массив если их несколько.
+                    // имя аргумента в конструкторе
+                    inputRule: diAutowire(RuleB::class),
+                    inputRule2: diAutowire(RuleA::class),
+                    inputRule3: diGet('ruleC'), // <-- получение по ссылке
                 ),
         ];
 
@@ -52,9 +49,9 @@ class VariadicArgumentTest extends TestCase
 
         $ruleGenerator = $container->get(RuleGenerator::class);
 
-        $this->assertInstanceOf(RuleB::class, $ruleGenerator->getRules()[0]);
-        $this->assertInstanceOf(RuleA::class, $ruleGenerator->getRules()[1]);
-        $this->assertInstanceOf(RuleC::class, $ruleGenerator->getRules()[2]);
+        $this->assertInstanceOf(RuleB::class, $ruleGenerator->getRules()['inputRule']);
+        $this->assertInstanceOf(RuleA::class, $ruleGenerator->getRules()['inputRule2']);
+        $this->assertInstanceOf(RuleC::class, $ruleGenerator->getRules()['inputRule3']);
     }
 
     public function testVariadicArgumentByIndex(): void
@@ -83,12 +80,12 @@ class VariadicArgumentTest extends TestCase
     {
         $definition = [
             diAutowire(ParameterIterableVariadic::class)
-                ->bindArguments(parameter: diValue(['first'])),
+                ->bindArguments(parameter: ['first']),
         ];
 
         $container = (new DiContainerFactory())->make($definition);
 
-        $this->assertEquals(['first'], $container->get(ParameterIterableVariadic::class)->getParameters()[0]);
+        $this->assertEquals(['first'], $container->get(ParameterIterableVariadic::class)->getParameters()['parameter']);
     }
 
     public function testVariadicArgumentByIndexForIterableParameter(): void

--- a/tests/Traits/ParametersResolver/DeprecatedMethodAddArgumentTest.php
+++ b/tests/Traits/ParametersResolver/DeprecatedMethodAddArgumentTest.php
@@ -54,9 +54,10 @@ class DeprecatedMethodAddArgumentTest extends TestCase
         $fn = static fn (iterable ...$iterator) => $iterator;
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
 
-        $this->addArgument('iterator', [[], []]);
+        $this->addArgument('iterator', []);
+        $this->addArgument('iterator2', []);
 
-        $this->assertEquals([[], []], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
+        $this->assertEquals(['iterator' => [], 'iterator2' => []], call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false)));
     }
 
     public function testAddArgumentFailByName(): void

--- a/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTaggedAsTest.php
@@ -92,10 +92,8 @@ class ParameterResolveByTaggedAsTest extends TestCase
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
 
         $this->bindArguments(
-            item: [
-                diTaggedAs('tags.tag-one'),
-                diTaggedAs('tags.tag-two'),
-            ]
+            diTaggedAs('tags.tag-one'),
+            diTaggedAs('tags.tag-two'),
         );
 
         $mockContainer = $this->createMock(DiContainerInterface::class);

--- a/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByTypeOrArgumentNameTest.php
@@ -91,10 +91,10 @@ class ParameterResolveByTypeOrArgumentNameTest extends TestCase
 
         $this->assertCount(2, $params);
         $this->assertInstanceOf(SuperClass::class, $params[0]);
-        $this->assertEquals('one', $params[1]);
+        $this->assertEquals('one', $params['word']);
 
         $this->assertInstanceOf(SuperClass::class, call_user_func_array($fn, $params)[0]);
-        $this->assertEquals(['one'], call_user_func_array($fn, $params)[1]);
+        $this->assertEquals(['word' => 'one'], call_user_func_array($fn, $params)[1]);
     }
 
     public function testParameterResolveByNameVariadicParameterArray(): void

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest.php
@@ -92,10 +92,8 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
 
         // 🚩 test data
         $this->bindArguments(
-            item: [
-                diAutowire(SuperClass::class),
-                diAutowire(SuperDiFactory::class),
-            ]
+            diAutowire(SuperClass::class),
+            diAutowire(SuperDiFactory::class),
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
@@ -121,16 +119,14 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
 
         // 🚩 test data
         $this->bindArguments(
-            item: [
-                diAutowire(SuperClass::class),
-                diAutowire(MoreSuperClass::class),
-            ]
+            item: diAutowire(SuperClass::class),
+            item2: diAutowire(MoreSuperClass::class),
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
-        $this->assertInstanceOf(SuperClass::class, $res[0]);
-        $this->assertInstanceOf(MoreSuperClass::class, $res[1]);
+        $this->assertInstanceOf(SuperClass::class, $res['item']);
+        $this->assertInstanceOf(MoreSuperClass::class, $res['item2']);
     }
 
     public function testResolveByAutowireDefinitionVariadicByArrayAndSingletonByName(): void
@@ -143,10 +139,8 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
 
         // 🚩 test data
         $this->bindArguments(
-            item: [
-                diAutowire(SuperClass::class, true),
-                diAutowire(MoreSuperClass::class, true),
-            ]
+            diAutowire(SuperClass::class, true),
+            diAutowire(MoreSuperClass::class, true),
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
@@ -179,10 +173,8 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
 
         // 🚩 test data
         $this->bindArguments(
-            item: [
-                diGet('services.super.one'),
-                diGet('services.super.two'),
-            ]
+            diGet('services.super.one'),
+            diGet('services.super.two'),
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
@@ -218,5 +210,25 @@ class ParameterResolveByUserDefinedArgumentByDiAutowireDefinitionInterfaceTest e
         $this->assertCount(2, $res);
         $this->assertInstanceOf(MoreSuperClass::class, $res[0]);
         $this->assertInstanceOf(SuperClass::class, $res[1]);
+    }
+
+    public function testResolveVariadicAsOptional(): void
+    {
+        $fn = static fn (SuperInterface ...$item) => $item;
+        $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
+
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer
+            ->expects(self::never())
+            ->method('get')
+            ->willReturnMap([
+                [SuperInterface::class, new MoreSuperClass()],
+            ])
+        ;
+        $this->setContainer($mockContainer);
+
+        $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
+
+        $this->assertEquals([], $res);
     }
 }

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByDiReferenceTest.php
@@ -70,11 +70,9 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->setContainer($mockContainer);
         // 🚩 test data
         $this->bindArguments(
-            iterator: [
-                diGet('services.icon-iterator.one'),
-                diGet('services.icon-iterator.two'),
-            ],
-            name: 'Piter'
+            name: 'Piter',
+            iterator: diGet('services.icon-iterator.one'),
+            iterator2: diGet('services.icon-iterator.two'),
         );
 
         [$name, $res] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
@@ -82,11 +80,11 @@ class ParameterResolveByUserDefinedArgumentByDiReferenceTest extends TestCase
         $this->assertEquals('Piter', $name);
         $this->assertCount(2, $res);
 
-        $this->assertInstanceOf(ArrayIterator::class, $res[0]);
-        $this->assertEquals(['🚀'], $res[0]->getArrayCopy());
+        $this->assertInstanceOf(ArrayIterator::class, $res['iterator']);
+        $this->assertEquals(['🚀'], $res['iterator']->getArrayCopy());
 
-        $this->assertInstanceOf(ArrayIterator::class, $res[1]);
-        $this->assertEquals(['🔥'], $res[1]->getArrayCopy());
+        $this->assertInstanceOf(ArrayIterator::class, $res['iterator2']);
+        $this->assertEquals(['🔥'], $res['iterator2']->getArrayCopy());
     }
 
     public function testUserDefinedArgumentByManydiGetVariadicByIndex(): void

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentByRawValueTest.php
@@ -91,9 +91,9 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         $this->assertEquals(['ddd', 'eee', 'fff'], $iter[1]);
     }
 
-    public function testUserDefinedArgumentAsArrayVariadicByNameSuccess(): void
+    public function testUserDefinedArgumentVariadicByOtherNamedArgNameSuccess(): void
     {
-        $fn = static fn (iterable ...$iterator) => $iterator;
+        $fn = static fn (string $str = '', iterable ...$iterator) => [$str, $iterator];
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
 
         $mockContainer = $this->createMock(DiContainerInterface::class);
@@ -101,17 +101,15 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         $this->setContainer($mockContainer);
 
         // 🚩 test data
-        $this->bindArguments(iterator: [
-            ['aaa', 'bbb', 'ccc'],
-            ['ddd', 'eee', 'fff'],
-        ]);
+        $this->bindArguments(iterator1: ['aaa', 'bbb', 'ccc'], iterator2: ['ddd', 'eee', 'fff'], str: 'welcome');
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertCount(2, $res);
 
-        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res[0]);
-        $this->assertEquals(['ddd', 'eee', 'fff'], $res[1]);
+        $this->assertEquals('welcome', $res[0]);
+        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res[1]['iterator1']);
+        $this->assertEquals(['ddd', 'eee', 'fff'], $res[1]['iterator2']);
     }
 
     public function testUserDefinedArgumentOneVariadicByNameWrappedByDiValue(): void
@@ -130,7 +128,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
 
         $this->assertCount(1, $res);
 
-        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res[0]);
+        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res['iterator']);
     }
 
     public function testUserDefinedArgumentAsStringVariadicByIndexSuccess(): void
@@ -164,7 +162,7 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
         $this->setContainer($mockContainer);
 
         // 🚩 test data, unsorted parameter names
-        $this->bindArguments(word: ['aaa', 'bbb', 'ccc'], numbers: [1_000, 10_000]);
+        $this->bindArguments(word: 'aaa', word2: 'bbb', wor3: 'ccc', numbers: [1_000, 10_000]);
 
         [$numbers, $word] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
@@ -174,9 +172,9 @@ class ParameterResolveByUserDefinedArgumentByRawValueTest extends TestCase
 
         $this->assertCount(3, $word);
 
-        $this->assertEquals('aaa', $word[0]);
-        $this->assertEquals('bbb', $word[1]);
-        $this->assertEquals('ccc', $word[2]);
+        $this->assertEquals('aaa', $word['word']);
+        $this->assertEquals('bbb', $word['word2']);
+        $this->assertEquals('ccc', $word['wor3']);
     }
 
     public function testUserDefinedArgumentAsStdClassByIndexAndName(): void

--- a/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest.php
@@ -65,18 +65,16 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
 
         // 🚩 test data
         $this->bindArguments(
-            iterator: [
-                ['aaa', 'bbb', 'ccc'],
-                ['ddd', 'eee', 'fff'],
-            ]
+            iterator1: ['aaa', 'bbb', 'ccc'],
+            iterator2: ['ddd', 'eee', 'fff'],
         );
 
         $res = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, true));
 
         $this->assertCount(2, $res);
 
-        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res[0]);
-        $this->assertEquals(['ddd', 'eee', 'fff'], $res[1]);
+        $this->assertEquals(['aaa', 'bbb', 'ccc'], $res['iterator1']);
+        $this->assertEquals(['ddd', 'eee', 'fff'], $res['iterator2']);
     }
 
     public function testUserDefinedArgumentVariadicOneByName(): void
@@ -97,7 +95,7 @@ class ParameterResolveByUserDefinedArgumentBySimpleDiDefinitionTest extends Test
 
         $this->assertCount(1, $res);
 
-        $this->assertEquals('hi my darling', $res[0]);
+        $this->assertEquals('hi my darling', $res['str']);
     }
 
     public function testUserDefinedArgumentByIndexVariadicSuccess(): void

--- a/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
+++ b/tests/Traits/ParametersResolver/ParameterResolveUserDefinedArgumentByProxyClosureTest.php
@@ -171,13 +171,11 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
 
         // 🚩 test data
         $this->bindArguments(
-            item: [
-                diProxyClosure(MoreSuperClass::class),
-                diProxyClosure(SuperClass::class),
-            ]
+            item1: diProxyClosure(MoreSuperClass::class),
+            item2: diProxyClosure(SuperClass::class),
         );
 
-        [$res1, $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        ['item1' => $res1, 'item2' => $res2] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertInstanceOf(Closure::class, $res1);
         $this->assertInstanceOf(Closure::class, $res2);
@@ -209,15 +207,13 @@ class ParameterResolveUserDefinedArgumentByProxyClosureTest extends TestCase
         // 🚩 test data
         $reflectionParameters = (new ReflectionFunction($fn))->getParameters();
         $this->bindArguments(
-            item: [
-                diProxyClosure(MoreSuperClass::class, false),
-                diProxyClosure(SuperClass::class, true),
-                diProxyClosure(MoreSuperClass::class, false),
-            ]
+            item: diProxyClosure(MoreSuperClass::class, false),
+            item2: diProxyClosure(SuperClass::class, true),
+            item3: diProxyClosure(MoreSuperClass::class, false),
         );
 
-        [$res11, $res12, $res13] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
-        [$res21, $res22, $res23] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        ['item' => $res11, 'item2' => $res12, 'item3' => $res13] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
+        ['item' => $res21, 'item2' => $res22, 'item3' => $res23] = call_user_func_array($fn, $this->resolveParameters($this->getBindArguments(), $reflectionParameters, false));
 
         $this->assertNotSame($res11, $res13);
         $this->assertNotSame($res21, $res23);


### PR DESCRIPTION
Аргументы для параметра переменной длины будут работать в соотвествии с правилами описаными в PHP документации для именовых аргументов  [тут](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments) и [тут](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list).

следующий вызов корректно сработает:
```php
use Kaspi\DiContainer\diAutowire;
use Kaspi\DiContainer\DiContainerFactory;

class Foo {
    function __construct(string $s = 'default', int ...$point) {
        var_dump($point);
    }
}

$container = (new DiContainerFactory())->make([
   'foo.default' => diAutowire(Foo::class),

   'foo.named_one => diAutowire(Foo::class)
        ->bindArguments(point: 10, point_2: 20, point_3: 30),

   'foo.named_two' => diAutowire(Foo::class)
        ->bindArguments(point_one: 10, point_two: 20, point_three: 30),
]);
```