### PR TITLE
Drooping support string  `@container-identifier` as container identifier.

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -700,7 +700,7 @@ $classWithHeavyDep->doHeavyDependency();
  - `\ArrayAccess`
  - `\Psr\Container\ContainerInterface`
  - `array` требуется использовать параметр `$isLazy = false`.
- - Составной тип (_intersection types PHP 8.1 и выше_) для ленивых коллекций (`$isLazy = true`) 
+ - Составной тип (_intersection types_) для ленивых коллекций (`$isLazy = true`)
    - `\ArrayAccess&\Iterator&\Psr\Container\ContainerInterface`. 
 ```php
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;

--- a/docs/05-tags.md
+++ b/docs/05-tags.md
@@ -8,7 +8,7 @@
 - `\ArrayAccess`
 - `\Psr\Container\ContainerInterface`
 - `array` требуется использовать параметр `$isLazy = false`.
-- Составной тип (_intersection types PHP 8.1 и выше_) для ленивых коллекций (`$isLazy = true`)
+- Составной тип (_intersection types_) для ленивых коллекций (`$isLazy = true`)
     - `\ArrayAccess&\Iterator&\Psr\Container\ContainerInterface`.
 
 Любое определение в контейнере может быть отмечено

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -25,7 +25,6 @@ use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
 use ReflectionException;
 
-use function array_map;
 use function get_class;
 use function get_debug_type;
 use function is_object;
@@ -328,10 +327,7 @@ final class DiDefinitionAutowire implements DiDefinitionConfigAutowireInterface,
         foreach ($this->getSetupAttribute($this->getDefinition()) as $setupAttr) {
             $this->setupByAttributes[$setupAttr->getIdentifier()][] = [
                 $setupAttr->isImmutable(),
-                array_map(
-                    static fn (mixed $arg) => self::convertStringArgumentToDiDefinitionGet($arg),
-                    $setupAttr->getArguments()
-                ),
+                $setupAttr->getArguments(),
             ];
         }
 

--- a/src/DiContainer/Traits/DiAutowireTrait.php
+++ b/src/DiContainer/Traits/DiAutowireTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Traits;
 
-use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use ReflectionNamedType;
@@ -17,8 +16,6 @@ use function implode;
 use function is_callable;
 use function is_string;
 use function sprintf;
-use function str_starts_with;
-use function substr;
 use function trim;
 
 trait DiAutowireTrait
@@ -71,24 +68,5 @@ trait DiAutowireTrait
         };
 
         return array_diff($types, $type);
-    }
-
-    /**
-     * Convention for string value in argument:
-     *  - 'raw str' raw value, as is
-     * - '@container-identifier' convert to new DiDefinitionGet('container-identifier')
-     * - '@@container-identifier' convert to string '@container-identifier'
-     */
-    private static function convertStringArgumentToDiDefinitionGet(mixed $arg): mixed
-    {
-        if (is_string($arg) && str_starts_with($arg, '@')) {
-            return match (true) {
-                str_starts_with($arg, '@@') => substr($arg, 1),
-                '' !== ($id = substr($arg, 1)) => new DiDefinitionGet($id),
-                default => $arg
-            };
-        }
-
-        return $arg;
     }
 }

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleBar.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleBar.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+final class RuleBar implements RuleInterface {}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleFoo.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleFoo.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+final class RuleFoo implements RuleInterface {}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleInterface.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/RuleInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+interface RuleInterface {}

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupByAttributeWithArgumentAsReference.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupByAttributeWithArgumentAsReference.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
 
 use Kaspi\DiContainer\Attributes\Setup;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet as DiGet;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionValue as DiValue;
 
 final class SetupByAttributeWithArgumentAsReference
 {
@@ -47,20 +49,20 @@ final class SetupByAttributeWithArgumentAsReference
         return $this->anyAsString;
     }
 
-    #[Setup(someClass: '@services.some_class')]
+    #[Setup(someClass: new DiGet('services.some_class'))]
     public function setSomeClassAsContainerIdentifier($someClass, SomeClass $class): void
     {
         $this->someClass = $someClass;
         $this->dependencyAutoResolve = $class;
     }
 
-    #[Setup(any: '@services.any_string')]
+    #[Setup(any: new DiGet('services.any_string'))]
     public function setAnyAsContainerIdentifier(string $any): void
     {
         $this->anyAsContainerIdentifier = $any;
     }
 
-    #[Setup(any: '@@la-la-la')]
+    #[Setup(any: new DiValue('@@la-la-la'))]
     public function setAnyAsEscapedString(string $any): void
     {
         $this->anyAsEscapedString = $any;

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttributeWithArgumentAsDefinition.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/SetupImmutableByAttributeWithArgumentAsDefinition.php
@@ -5,14 +5,22 @@ declare(strict_types=1);
 namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
 
 use Kaspi\DiContainer\Attributes\SetupImmutable;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet as DiGet;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs as DiTaggedAs;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionValue as DiValue;
 
-final class SetupImmutableByAttributeWithArgumentAsReference
+final class SetupImmutableByAttributeWithArgumentAsDefinition
 {
     private ?SomeClass $someClass = null;
     private ?string $anyAsContainerIdentifier = null;
     private ?string $anyAsEscapedString = null;
 
     private ?string $anyAsString = null;
+
+    /**
+     * @var iterable<RuleInterface>
+     */
+    private iterable $rules;
 
     /**
      * Will return SomeClass::SomeClass.
@@ -46,7 +54,7 @@ final class SetupImmutableByAttributeWithArgumentAsReference
         return $this->anyAsString;
     }
 
-    #[SetupImmutable(someClass: '@services.some_class')]
+    #[SetupImmutable(someClass: new DiGet('services.some_class'))]
     public function withSomeClassAsContainerIdentifier($someClass): self
     {
         $new = clone $this;
@@ -55,7 +63,7 @@ final class SetupImmutableByAttributeWithArgumentAsReference
         return $new;
     }
 
-    #[SetupImmutable(any: '@services.any_string')]
+    #[SetupImmutable(any: new DiGet('services.any_string'))]
     public function withAnyAsContainerIdentifier(string $any): self
     {
         $new = clone $this;
@@ -64,7 +72,7 @@ final class SetupImmutableByAttributeWithArgumentAsReference
         return $new;
     }
 
-    #[SetupImmutable(any: '@@la-la-la')]
+    #[SetupImmutable(any: new DiValue('@la-la-la'))]
     public function withAnyAsEscapedString(string $any): self
     {
         $new = clone $this;
@@ -80,5 +88,19 @@ final class SetupImmutableByAttributeWithArgumentAsReference
         $new->anyAsString = $anyAsString;
 
         return $new;
+    }
+
+    #[SetupImmutable(new DiTaggedAs('tags.rule_interface'))]
+    public function withRules(iterable $rules): self
+    {
+        $new = clone $this;
+        $new->rules = $rules;
+
+        return $new;
+    }
+
+    public function getRules(): iterable
+    {
+        return $this->rules;
     }
 }

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
@@ -10,11 +10,12 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use Kaspi\DiContainer\LazyDefinitionIterator;
 use PHPUnit\Framework\TestCase;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\ClassWithConstructDestruct;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutable;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutableByAttribute;
-use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutableByAttributeWithArgumentAsReference;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SetupImmutableByAttributeWithArgumentAsDefinition;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\SomeClass;
 
 use function Kaspi\DiContainer\diAutowire;
@@ -26,7 +27,10 @@ use function Kaspi\DiContainer\diAutowire;
  * @covers \Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire
  * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionGet
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs
+ * @covers \Kaspi\DiContainer\DiDefinition\DiDefinitionValue
  * @covers \Kaspi\DiContainer\diGet
+ * @covers \Kaspi\DiContainer\LazyDefinitionIterator
  * @covers \Kaspi\DiContainer\Traits\ParameterTypeByReflectionTrait
  *
  * @internal
@@ -160,12 +164,12 @@ class SetupImmutableTest extends TestCase
             ])
         ;
 
-        $def = (new DiDefinitionAutowire(SetupImmutableByAttributeWithArgumentAsReference::class))
+        $def = (new DiDefinitionAutowire(SetupImmutableByAttributeWithArgumentAsDefinition::class))
             ->setupImmutable('withSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
             ->setContainer($mockContainer)
         ;
 
-        /** @var SetupImmutableByAttributeWithArgumentAsReference $class */
+        /** @var SetupImmutableByAttributeWithArgumentAsDefinition $class */
         $class = $def->invoke();
 
         self::assertInstanceOf(SomeClass::class, $class->getSomeClass());
@@ -174,6 +178,7 @@ class SetupImmutableTest extends TestCase
         self::assertEquals('string from container', $class->getAnyAsContainerIdentifier());
         self::assertEquals('@la-la-la', $class->getAnyAsEscapedString());
         self::assertEquals('any_string', $class->getAnyAsString());
+        self::assertInstanceOf(LazyDefinitionIterator::class, $class->getRules());
     }
 
     /**

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
@@ -141,7 +141,7 @@ class SetupTest extends TestCase
         self::assertEquals('foo', $class->getSomeClass()->getValue());
 
         self::assertEquals('string from container', $class->getAnyAsContainerIdentifier());
-        self::assertEquals('@la-la-la', $class->getAnyAsEscapedString());
+        self::assertEquals('@@la-la-la', $class->getAnyAsEscapedString());
         self::assertEquals('la-la-la', $class->getAnyAsString());
     }
 

--- a/tests/Traits/AttributeReader/InjectCallable/InjectCallableTest.php
+++ b/tests/Traits/AttributeReader/InjectCallable/InjectCallableTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Traits\AttributeReader\InjectCallable;
 
-use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Traits\AttributeReaderTrait;


### PR DESCRIPTION
bc: [DiDefinitionAutowire] Drooping support the magic container identifier string aka `@container-identifier`.