### PR TITLE
Check resolved entry by container identifier via `array_key_exists`.

### DIFF
--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -106,7 +106,9 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     public function get(string $id): mixed
     {
-        return $this->resolved[$id] ?? $this->resolve($id);
+        return array_key_exists($id, $this->resolved)
+            ? $this->resolved[$id]
+            : $this->resolve($id);
     }
 
     public function has(string $id): bool


### PR DESCRIPTION
#278 