### PR TITLE
fix: [ContextExceptionInterface] Return type must be `static`.

### DIFF
--- a/src/DiContainer/Interfaces/Exceptions/ContextExceptionInterface.php
+++ b/src/DiContainer/Interfaces/Exceptions/ContextExceptionInterface.php
@@ -16,5 +16,5 @@ interface ContextExceptionInterface extends ContainerExceptionInterface
     /**
      * @return $this
      */
-    public function setContext(mixed ...$context): self;
+    public function setContext(mixed ...$context): static;
 }

--- a/src/DiContainer/Traits/ContextExceptionTrait.php
+++ b/src/DiContainer/Traits/ContextExceptionTrait.php
@@ -17,7 +17,7 @@ trait ContextExceptionTrait
         return $this->context;
     }
 
-    public function setContext(mixed ...$context): self
+    public function setContext(mixed ...$context): static
     {
         /**
          * @phpstan-var array<string|non-negative-int, mixed> $context


### PR DESCRIPTION
#324 