### PR TITLE
Expose container identifiers with keys from `DiDefinitionTaggedAsInterface`

### DIFF
--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -57,11 +57,9 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
 
     public function resolve(DiContainerInterface $container, mixed $context = null): iterable
     {
-        $mapKeyToContainerIdentifier = $this->makeMapTaggedKeyToContainerIdentifier($container, $context);
-
         return $this->isLazy
-            ? new LazyDefinitionIterator($container, $mapKeyToContainerIdentifier)
-            : array_map(static fn (string $id) => $container->get($id), $mapKeyToContainerIdentifier);
+            ? new LazyDefinitionIterator($container, $this->exposeContainerIdentifiers($container, $context))
+            : array_map(static fn (string $id) => $container->get($id), $this->exposeContainerIdentifiers($container, $context));
     }
 
     public function getDefinition(): string
@@ -74,7 +72,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
      *
      * @throws DiDefinitionExceptionInterface
      */
-    private function makeMapTaggedKeyToContainerIdentifier(DiContainerInterface $container, mixed $context): array
+    public function exposeContainerIdentifiers(DiContainerInterface $container, mixed $context = null): iterable
     {
         if ($context instanceof DiDefinitionAutowireInterface) {
             $this->callingByDefinitionAutowire = $context;

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionTaggedAsInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionTaggedAsInterface.php
@@ -25,4 +25,20 @@ interface DiDefinitionTaggedAsInterface extends DiDefinitionInterface
      * @throws DiDefinitionExceptionInterface
      */
     public function resolve(DiContainerInterface $container, mixed $context = null): iterable;
+
+    /**
+     * Expose tagged container identifiers with keys.
+     *
+     * @return iterable<non-empty-string|non-negative-int, non-empty-string>
+     *
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function exposeContainerIdentifiers(DiContainerInterface $container, mixed $context = null): iterable;
+
+    /**
+     * Tag name.
+     *
+     * @return non-empty-string
+     */
+    public function getDefinition(): string;
 }


### PR DESCRIPTION
#360 

Новый метод `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface::exposeContainerIdentifiers(): iterable`

Имплементация его в `\Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs::exposeContainerIdentifiers()`.