### PR TITLE
Change signature DiContainerInterface::getConfig().

### DIFF
--- a/src/DiContainer/DiContainerConfig.php
+++ b/src/DiContainer/DiContainerConfig.php
@@ -9,9 +9,9 @@ use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
 final class DiContainerConfig implements DiContainerConfigInterface
 {
     public function __construct(
-        private bool $useZeroConfigurationDefinition = true,
-        private bool $useAttribute = true,
-        private bool $isSingletonServiceDefault = false,
+        private readonly bool $useZeroConfigurationDefinition = true,
+        private readonly bool $useAttribute = true,
+        private readonly bool $isSingletonServiceDefault = false,
     ) {}
 
     public function isSingletonServiceDefault(): bool

--- a/src/DiContainer/DiContainerFactory.php
+++ b/src/DiContainer/DiContainerFactory.php
@@ -6,15 +6,11 @@ namespace Kaspi\DiContainer;
 
 use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
 use Kaspi\DiContainer\Interfaces\DiContainerFactoryInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 
 final class DiContainerFactory implements DiContainerFactoryInterface
 {
-    public function __construct(private ?DiContainerConfigInterface $config = null) {}
+    public function __construct(private readonly ?DiContainerConfigInterface $config = null) {}
 
-    /**
-     * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
-     */
     public function make(iterable $definitions = []): DiContainer
     {
         $config = $this->config ?? new DiContainerConfig(

--- a/src/DiContainer/DiContainerNullConfig.php
+++ b/src/DiContainer/DiContainerNullConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer;
+
+use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
+
+final class DiContainerNullConfig implements DiContainerConfigInterface
+{
+    public function isSingletonServiceDefault(): bool
+    {
+        return false;
+    }
+
+    public function isUseZeroConfigurationDefinition(): bool
+    {
+        return false;
+    }
+
+    public function isUseAttribute(): bool
+    {
+        return false;
+    }
+}

--- a/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
+++ b/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
@@ -40,8 +40,6 @@ use function sprintf;
  */
 final class ArgumentBuilder implements ArgumentBuilderInterface
 {
-    private readonly bool $isUseAttribute;
-
     /**
      * @param BindArgumentsType $bindArguments
      */
@@ -49,9 +47,7 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
         private readonly array $bindArguments,
         private readonly ReflectionFunctionAbstract $functionOrMethod,
         private readonly DiContainerInterface $container,
-    ) {
-        $this->isUseAttribute = $this->container->getConfig()?->isUseAttribute() ?? false;
-    }
+    ) {}
 
     public function getBindArguments(): array
     {
@@ -70,14 +66,14 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
 
     public function build(): array
     {
-        return $this->isUseAttribute
+        return $this->container->getConfig()->isUseAttribute()
             ? $this->basedOnPhpAttributes()
             : $this->basedOnBindArguments();
     }
 
     public function buildByPriorityBindArguments(): array
     {
-        return $this->isUseAttribute
+        return $this->container->getConfig()->isUseAttribute()
             ? $this->basedOnBindArgumentsAsPriorityAndPhpAttributes()
             : $this->basedOnBindArguments();
     }

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -354,7 +354,7 @@ final class DiDefinitionAutowire implements DiDefinitionSetupAutowireInterface, 
      */
     private function getTagsByAttribute(): array
     {
-        if (false === (bool) $this->getContainer()->getConfig()?->isUseAttribute()) {
+        if (!$this->getContainer()->getConfig()->isUseAttribute()) {
             return [];
         }
 

--- a/src/DiContainer/Interfaces/DiContainerFactoryInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerFactoryInterface.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Interfaces;
 
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
-use Psr\Container\ContainerExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 
 interface DiContainerFactoryInterface
 {
     /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
      *
-     * @throws ContainerExceptionInterface
+     * @throws ContainerAlreadyRegisteredExceptionInterface|ContainerIdentifierExceptionInterface
      */
     public function make(
         iterable $definitions = [],

--- a/src/DiContainer/Interfaces/DiContainerInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerInterface.php
@@ -40,7 +40,7 @@ interface DiContainerInterface extends ContainerInterface
      */
     public function getDefinitions(): iterable;
 
-    public function getConfig(): ?DiContainerConfigInterface;
+    public function getConfig(): DiContainerConfigInterface;
 
     /**
      * @param non-empty-string $tag

--- a/src/DiContainer/Traits/SetupConfigureTrait.php
+++ b/src/DiContainer/Traits/SetupConfigureTrait.php
@@ -64,7 +64,7 @@ trait SetupConfigureTrait
      */
     private function getSetups(ReflectionClass $class, DiContainerInterface $container): array
     {
-        if (false === (bool) $container->getConfig()?->isUseAttribute()) {
+        if (!$container->getConfig()->isUseAttribute()) {
             return $this->setup;
         }
 

--- a/tests/DiContainer/Has/DiContainerHasTest.php
+++ b/tests/DiContainer/Has/DiContainerHasTest.php
@@ -8,6 +8,7 @@ use Generator;
 use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiContainerNullConfig;
 use Kaspi\DiContainer\Helper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -25,6 +26,7 @@ use Tests\DiContainer\Has\Fixtures\MyInterface;
 #[CoversClass(DiContainer::class)]
 #[CoversClass(DiContainerConfig::class)]
 #[CoversClass(Helper::class)]
+#[CoversClass(DiContainerNullConfig::class)]
 class DiContainerHasTest extends TestCase
 {
     public function testHasDefinitionWithNull(): void

--- a/tests/DiContainerCall/CallFunctionTest.php
+++ b/tests/DiContainerCall/CallFunctionTest.php
@@ -9,6 +9,7 @@ use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\DefinitionDiCall;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiContainerNullConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
@@ -50,6 +51,7 @@ use function round;
 #[CoversClass(Helper::class)]
 #[CoversClass(ReflectionMethodByDefinition::class)]
 #[CoversClass(NotFoundException::class)]
+#[CoversClass(DiContainerNullConfig::class)]
 class CallFunctionTest extends TestCase
 {
     public function testBuiltinFunction(): void


### PR DESCRIPTION
#365 

bc: [DiContainerInterface, DiContainer] `\Kaspi\DiContainer\Interfaces\DiContainerInterface::getConfig()` always return container config.

feat: [DiContainerNullConfig] Config with switch off all feature DiContainer.

refactor: [ArgumentBuilder] Check available using php attributes from container configuration.

refactor: [DiDefinitionAutowire] Container configuration always exist.

refactor: [SetupConfigureTrait] Container configuration always exist.

refactor: [DiContainerConfig] Promote property marked as readonly.