### PR TITLE
Parameter with default value don't resolve via type hint.

### DIFF
--- a/tests/DiContainerCall/CallFunctionTest.php
+++ b/tests/DiContainerCall/CallFunctionTest.php
@@ -144,7 +144,7 @@ class CallFunctionTest extends TestCase
     public function testUserFunctionUnresolvedArgument(): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessageMatches('/Cannot resolve parameter at position #0.+funcWithDependencyClass()/');
+        $this->expectExceptionMessageMatches('/Cannot build argument via type hint for Parameter #0.+funcWithDependencyClass()/');
 
         (new DiContainer())->call('\Tests\DiContainerCall\Fixtures\funcWithDependencyClass');
     }

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
@@ -63,12 +63,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
 {
     use BindArgumentsTrait;
 
-    private DiContainerInterface $container;
+    private DiContainerInterface $mockContainer;
 
     public function setUp(): void
     {
-        $this->container = $this->createMock(DiContainerInterface::class);
-        $this->container->method('getConfig')
+        $this->mockContainer = $this->createMock(DiContainerInterface::class);
+        $this->mockContainer->method('getConfig')
             ->willReturn(
                 new DiContainerConfig(
                     useAttribute: true
@@ -84,7 +84,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
 
         $this->bindArguments(quux: diGet('services.quux'));
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -107,7 +107,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             other_two: diGet('services.bar'),
             other_three: diGet('services.baz'),
         );
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $ba->build();
     }
@@ -115,7 +115,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
     public function testInjectRegularParameters(): void
     {
         $fn = static fn (#[Inject(Quux::class)] QuuxInterface $quux) => $quux;
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -130,7 +130,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             QuuxInterface ...$quux
         ) => $quux;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(Baz::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -151,7 +156,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             QuuxInterface $quux,
         ) => ($heavyDependency)()->doMake($quux);
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -178,7 +188,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             Closure ...$heavyDependency,
         ): array => [($heavyDependency[0])()->doMake($quux), ($heavyDependency[1])()->doMake($quux)];
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -200,7 +215,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             callable $doCallable,
         ) => ($doCallable)($quux);
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -222,7 +242,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             callable ...$doCallable,
         ) => true;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -244,7 +269,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             iterable $validators,
         ) => true;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -266,7 +296,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             iterable ...$validator,
         ) => true;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(QuuxInterface::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -292,7 +327,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
 
         $this->bindArguments(bar: diCallable([Baz::class, 'doMake']));
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -311,7 +346,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             Baz ...$baz,                // parameter #2
         ) => true;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $args = $ba->build();
 
@@ -324,7 +359,7 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
     {
         $fn = static fn (?Bar $bar = null, #[Inject] ?BazInterface $baz = null, Foo ...$foo) => $baz;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $arg = $ba->build();
 
@@ -341,7 +376,12 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
             Foo ...$foo
         ) => $baz;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(Bar::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         $arg = $ba->build();
 

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
@@ -42,12 +42,12 @@ class BuildArgumentsByPriorityBindArgumentsTest extends TestCase
 {
     use BindArgumentsTrait;
 
-    private DiContainerInterface $container;
+    private DiContainerInterface $mockContainer;
 
     public function setUp(): void
     {
-        $this->container = $this->createMock(DiContainerInterface::class);
-        $this->container->method('getConfig')
+        $this->mockContainer = $this->createMock(DiContainerInterface::class);
+        $this->mockContainer->method('getConfig')
             ->willReturn(
                 new DiContainerConfig(
                     useAttribute: true
@@ -63,7 +63,12 @@ class BuildArgumentsByPriorityBindArgumentsTest extends TestCase
 
         $this->bindArguments(quux: diGet('services.quux'));
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $this->mockContainer->method('has')
+            ->with(Bar::class)
+            ->willReturn(true)
+        ;
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         // 🚩 Use Php attribute and bind arguments - bind arguments highest priority.
         $args = $ba->buildByPriorityBindArguments();
@@ -82,7 +87,7 @@ class BuildArgumentsByPriorityBindArgumentsTest extends TestCase
     {
         $fn = static fn (#[Inject(Quux::class)] QuuxInterface $quux, #[Inject(Baz::class), Inject('service.one')] Foo $foo) => $quux;
 
-        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->container);
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
 
         try {
             // 🚩 Use Php attribute and bind arguments - bind arguments highest priority.

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
@@ -135,6 +135,11 @@ class SetupTest extends TestCase
                 ['services.any_string', 'string from container'],
             ])
         ;
+        // Default class SomeClass must exist in container
+        $mockContainer->method('has')
+            ->with(SomeClass::class)
+            ->willReturn(true)
+        ;
 
         $def = (new DiDefinitionAutowire(SetupByAttributeWithArgumentAsReference::class))
             ->setup('setSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method

--- a/tests/Integration/ResolveParameterWithDefaultValue/Fixtures/Bar.php
+++ b/tests/Integration/ResolveParameterWithDefaultValue/Fixtures/Bar.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ResolveParameterWithDefaultValue\Fixtures;
+
+use ArrayIterator;
+
+final class Bar
+{
+    public function __construct(public readonly ArrayIterator $bar = new ArrayIterator(['foo', 'bar'])) {}
+}

--- a/tests/Integration/ResolveParameterWithDefaultValue/ResolveParameterByTypeNotFoundWithDefaultValueTest.php
+++ b/tests/Integration/ResolveParameterWithDefaultValue/ResolveParameterByTypeNotFoundWithDefaultValueTest.php
@@ -7,8 +7,8 @@ namespace Tests\Integration\ResolveParameterWithDefaultValue;
 use Kaspi\DiContainer\DiContainer;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use Tests\Integration\ResolveParameterWithDefaultValue\Fixtures\Bar;
 use Tests\Integration\ResolveParameterWithDefaultValue\Fixtures\Foo;
-
 use function Kaspi\DiContainer\diAutowire;
 
 /**
@@ -24,5 +24,14 @@ class ResolveParameterByTypeNotFoundWithDefaultValueTest extends TestCase
         ]);
 
         self::assertNull($container->get(Foo::class)->bar);
+    }
+
+    public function testDefaultValueAsObject(): void
+    {
+        $container = new DiContainer([
+            diAutowire(Bar::class),
+        ]);
+
+        self::assertEquals(['foo', 'bar'], $container->get(Bar::class)->bar->getArrayCopy());
     }
 }


### PR DESCRIPTION
#379 

Для параметров функции (метода) если есть значение по умолчанию то его не нужно пытаться определить через тип параметра `type hint` и попытки найти в контейнере этот тип.