### PR TITLE
Definitions loader, configure definition from import.

### DIFF
--- a/tests/DefinitionsLoader/DefinitionLoaderImportCacheTest.php
+++ b/tests/DefinitionsLoader/DefinitionLoaderImportCacheTest.php
@@ -96,7 +96,7 @@ class DefinitionLoaderImportCacheTest extends TestCase
         ;
 
         (new DefinitionsLoader(importCacheFile: $dir->url().'/cache.php'))
-            ->import('App\\', __DIR__)
+            ->import('Tests\\', __DIR__.'/Fixtures/ImportCannotCreateCache')
             ->definitions()
             ->valid()
         ;
@@ -148,6 +148,7 @@ class DefinitionLoaderImportCacheTest extends TestCase
             'Tests\DefinitionsLoader\Fixtures\ImportCreating\One',
             'Tests\DefinitionsLoader\Fixtures\ImportCreating\Foo',
             'Tests\DefinitionsLoader\Fixtures\ImportCreating\Factory\FactoryFoo',
+            'services.any',
         ];
 
         sort($getKeys);
@@ -163,6 +164,9 @@ class DefinitionLoaderImportCacheTest extends TestCase
         $srvOI = $arr['Tests\DefinitionsLoader\Fixtures\ImportCreating\Interfaces\OtherInterface'];
         $this->assertInstanceOf(DiDefinitionGet::class, $srvOI);
         $this->assertEquals('services.any', $srvOI->getDefinition());
+
+        // Class Tests\DefinitionsLoader\Fixtures\ImportCreating\Bar autoconfigured via php attribute Autowire with container id = 'services.any'
+        $this->assertEquals('Tests\DefinitionsLoader\Fixtures\ImportCreating\Bar', $arr['services.any']->getIdentifier());
 
         $this->assertNull($arr['Tests\DefinitionsLoader\Fixtures\ImportCreating\One']->isSingleton());
 

--- a/tests/DefinitionsLoader/Fixtures/ImportCannotCreateCache/Foo.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportCannotCreateCache/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportCannotCreateCache;
+
+final class Foo {}

--- a/tests/DefinitionsLoader/Fixtures/ImportClassesViaSameId/Bar.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportClassesViaSameId/Bar.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportClassesViaSameId;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+
+#[Autowire(id: 'services.one')]
+final class Bar {}

--- a/tests/DefinitionsLoader/Fixtures/ImportClassesViaSameId/Foo.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportClassesViaSameId/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportClassesViaSameId;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+
+#[Autowire(id: 'services.one')]
+final class Foo {}

--- a/tests/DefinitionsLoader/Fixtures/ImportConfigInterface/Foo.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportConfigInterface/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportConfigInterface;
+
+final class Foo implements FooInterface {}

--- a/tests/DefinitionsLoader/Fixtures/ImportConfigInterface/FooInterface.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportConfigInterface/FooInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportConfigInterface;
+
+use Kaspi\DiContainer\Attributes\Service;
+
+#[Service('services.foo')]
+interface FooInterface {}

--- a/tests/DefinitionsLoader/Fixtures/ImportConfigInterfaceViaPhpAttribute/Foo.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportConfigInterfaceViaPhpAttribute/Foo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportConfigInterfaceViaPhpAttribute;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+
+#[Autowire]
+#[Autowire(id: 'services.foo')]
+final class Foo implements FooInterface {}

--- a/tests/DefinitionsLoader/Fixtures/ImportConfigInterfaceViaPhpAttribute/FooInterface.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportConfigInterfaceViaPhpAttribute/FooInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportConfigInterfaceViaPhpAttribute;
+
+use Kaspi\DiContainer\Attributes\Service;
+
+#[Service('services.foo')]
+interface FooInterface {}

--- a/tests/DefinitionsLoader/Fixtures/ImportCreating/Bar.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportCreating/Bar.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportCreating;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+
+#[Autowire(id: 'services.any')]
+final class Bar implements Interfaces\OtherInterface {}

--- a/tests/DefinitionsLoader/Fixtures/ImportInvalidReferenceForInterface/FooInterface.php
+++ b/tests/DefinitionsLoader/Fixtures/ImportInvalidReferenceForInterface/FooInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\Fixtures\ImportInvalidReferenceForInterface;
+
+use Kaspi\DiContainer\Attributes\Service;
+
+#[Service('services.foo')]
+interface FooInterface {}

--- a/tests/Integration/ResolveParameterWithDefaultValue/ResolveParameterByTypeNotFoundWithDefaultValueTest.php
+++ b/tests/Integration/ResolveParameterWithDefaultValue/ResolveParameterByTypeNotFoundWithDefaultValueTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Tests\Integration\ResolveParameterWithDefaultValue\Fixtures\Bar;
 use Tests\Integration\ResolveParameterWithDefaultValue\Fixtures\Foo;
+
 use function Kaspi\DiContainer\diAutowire;
 
 /**


### PR DESCRIPTION
#382 

- Bug fix: Cannot autoconfigure two or more class via PHP attribute `Autowire` with identical id values.
- enhancement: Check valid container identifier in import classes.
