### PR TITLE
v3.15.1

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -30,7 +30,7 @@ return static function (): \Generator {
                 dsn: 'sqlite:/tmp/my.db'
             )
             // Вызвать метод "setAttribute" и предать параметры в него
-            ->setup('setAttribute', \PDO::ATTR_CASE, \PDO::CASE_UPPER),
+            ->setup('setAttribute', [\PDO::ATTR_CASE, \PDO::CASE_UPPER]),
 
 };
 ```
@@ -180,7 +180,7 @@ diAutowire(...)->bindArguments(var1: 'value 1', var2: 'value 2')
 
 **Дополнительная настройка сервиса через методы класса (mutable setters):**
 ```php 
-setup(string $method, mixed ...$argument)
+setup(string $method, array $arguments = [])
 ``` 
 Возвращаемое значение из вызываемого метода не учитывается при настройке сервиса,
 контейнер вернет экземпляр класса созданного через конструктор класса.
@@ -193,7 +193,7 @@ setup(string $method, mixed ...$argument)
 
 Можно указывать именованные аргументы:
 ```php
-diAutowire(...)->setup('classMethod', var1: 'value 1', var2: 'value 2')
+diAutowire(...)->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
 // $object->classMethod(string $var1, string $var2)
 ```
 Если в методе нет параметров или они могут быть разрешены автоматически, то аргументы указывать не нужно:
@@ -206,8 +206,8 @@ diAutowire(...)->setup('classMethod', var1: 'value 1', var2: 'value 2')
 При указании нескольких вызовов метода он будет вызван указанное количество раз и возможно с разными аргументами:
 ```php
 diAutowire(...)
-  ->setup('classMethod', var1: 'value 1', var2: 'value 2')
-  ->setup('classMethod', var1: 'value 3', var2: 'value 4')
+  ->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
+  ->setup('classMethod', ['var1' => 'value 3', 'var2' => 'value 4'])
   // $object->classMethod('value 1', 'value 2');
   // $object->classMethod('value 3', 'value 4');
 ```
@@ -217,7 +217,7 @@ diAutowire(...)
 
 **Дополнительная настройка сервиса через методы класса возвращающие значение (immutable setters):**
 ```php 
-setupImmutable(string $method, mixed ...$argument)
+setupImmutable(string $method, array $arguments = [])
 ``` 
 Возвращаемое значение метода должно быть `self`, `static`
 или того же класса, что и сам сервис,
@@ -1427,7 +1427,7 @@ use function Kaspi\DiContainer\diAutowire;
 return static function(): \Generator {
 
     yield 'priority_queue.get_data' => diAutowire(\SplPriorityQueue::class)
-        ->setup('setExtractFlags', \SplPriorityQueue::EXTR_DATA);
+        ->setup('setExtractFlags', [\SplPriorityQueue::EXTR_DATA]);
 
 };
 ```
@@ -1491,7 +1491,7 @@ return static function(): \Generator {
 
     yield diAutowire(App\SomeClass::class)
         // Будет возвращён объект из метода `withLogger`
-        ->setupImmutable('withLogger', diGet(App\Servces\FileLogger::class));
+        ->setupImmutable('withLogger', [diGet(App\Servces\FileLogger::class)]);
 };
 ```
 ```php

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -82,16 +82,16 @@ final class DiDefinitionAutowire implements DiDefinitionConfigAutowireInterface,
     /**
      * @return $this
      */
-    public function setup(string $method, mixed ...$argument): static
+    public function setup(string $method, array $arguments = []): static
     {
-        $this->setup[$method][] = [false, $argument];
+        $this->setup[$method][] = [false, $arguments];
 
         return $this;
     }
 
-    public function setupImmutable(string $method, mixed ...$argument): static
+    public function setupImmutable(string $method, array $arguments = []): static
     {
-        $this->setup[$method][] = [true, $argument];
+        $this->setup[$method][] = [true, $arguments];
 
         return $this;
     }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionConfigAutowireInterface.php
@@ -16,23 +16,23 @@ interface DiDefinitionConfigAutowireInterface extends DiDefinitionArgumentsInter
      *
      * User can set arguments by named argument:
      *
-     *       ->setup('classMethod', var1: 'value 1', var2: 'value 2')
+     *       ->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2')
      *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
      *
-     *       ->setup('classMethod', var1: new DiDefinitionGet('service.one'))
-     *       ->setup('classMethod', var1: new DiDefinitionGet('service.two'))
+     *       ->setup('classMethod', ['var1' => new DiDefinitionGet('service.one')])
+     *       ->setup('classMethod', ['var1' => new DiDefinitionGet('service.two')])
      *
      * User can set arguments by index argument:
      *
-     *      ->setup('classMethod', 'value 1', 'value 2')
+     *      ->setup('classMethod', ['value 1', 'value 2'])
      *      // bind parameters by index Class->classMethod('value 1', 'value 2')
      *
-     * @param non-empty-string                                                                          $method
-     * @param DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed ...$argument
+     * @param non-empty-string                                                                                                                    $method
+     * @param array<non-empty-string|non-negative-int, DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed> $arguments
      *
      * @return $this
      */
-    public function setup(string $method, mixed ...$argument): static;
+    public function setup(string $method, array $arguments = []): static;
 
     /**
      * Call immutable setter method for class with input arguments with return type aka self.
@@ -44,21 +44,21 @@ interface DiDefinitionConfigAutowireInterface extends DiDefinitionArgumentsInter
      *
      * User can set arguments by named argument:
      *
-     *       ->setupImmutable('classMethod', var1: 'value 1', var2: 'value 2')
+     *       ->setupImmutable('classMethod', ['var1' => 'value 1', 'var2' => 'value 2')
      *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
      *
-     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.one'))
-     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.two'))
+     *       ->setupImmutable('classMethod', ['var1' => new DiDefinitionGet('service.one')])
+     *       ->setupImmutable('classMethod', ['var1' => new DiDefinitionGet('service.two')])
      *
      * User can set arguments by index argument:
      *
-     *      ->setupImmutable('classMethod', 'value 1', 'value 2')
+     *      ->setupImmutable('classMethod', ['value 1', 'value 2'])
      *      // bind parameters by index Class->classMethod('value 1', 'value 2')
      *
-     * @param non-empty-string                                                                          $method
-     * @param DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed ...$argument
+     * @param non-empty-string                                                                                                                    $method
+     * @param array<non-empty-string|non-negative-int, DiDefinitionArgumentsInterface|DiDefinitionInterface|DiDefinitionInvokableInterface|mixed> $arguments
      *
      * @return $this
      */
-    public function setupImmutable(string $method, mixed ...$argument): static;
+    public function setupImmutable(string $method, array $arguments = []): static;
 }

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
@@ -134,8 +134,8 @@ class SetupImmutableTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupImmutableByAttribute::class))
-            ->setupImmutable('withSomeClass', someClass: null)
-            ->setupImmutable('withSomeClass', someClass: diAutowire(SomeClass::class)->bindArguments('aaa'))
+            ->setupImmutable('withSomeClass', ['someClass' => null])
+            ->setupImmutable('withSomeClass', ['someClass' => diAutowire(SomeClass::class)->bindArguments('aaa')])
 
             ->setContainer($this->mockContainer)
         ;
@@ -160,7 +160,7 @@ class SetupImmutableTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupImmutableByAttributeWithArgumentAsReference::class))
-            ->setupImmutable('withSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setupImmutable('withSomeClassAsContainerIdentifier', ['someClass' => null]) // overrode by php attribute on method
             ->setContainer($mockContainer)
         ;
 

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
@@ -36,10 +36,10 @@ class SetupTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
 
         $def = (new DiDefinitionAutowire(SetupClass::class))
-            ->setup('setName', newName: diValue('Vasiliy')) // first set name
-            ->setup('setName', diValue('Piter')) // override set name
-            ->setup('setParameters', paramName: diValue('key1'), parameters: ['One', 'Two', 'Three'])
-            ->setup('setParameters', 'key2', ['Four', 'Five', 'Six'])
+            ->setup('setName', ['newName' => diValue('Vasiliy')]) // first set name
+            ->setup('setName', [diValue('Piter')]) // override set name
+            ->setup('setParameters', ['paramName' => diValue('key1'), 'parameters' => ['One', 'Two', 'Three']])
+            ->setup('setParameters', ['key2', ['Four', 'Five', 'Six']])
         ;
         $def->setContainer($mockContainer);
 
@@ -96,8 +96,8 @@ class SetupTest extends TestCase
             ->setup('incInc')// override by php attribute #[Setup]
             ->setup('incInc') // override by php attribute #[Setup]
             ->setup('incInc') // override by php attribute #[Setup]
-            ->setup('setParameters', 'key1', ['One', 'Two', 'Three']) // override by php attribute #[Setup]
-            ->setup('setParameters', 'key2', ['X', 'Y', 'Z']) // override by php attribute #[Setup]
+            ->setup('setParameters', ['key1', ['One', 'Two', 'Three']]) // override by php attribute #[Setup]
+            ->setup('setParameters', ['key2', ['X', 'Y', 'Z']]) // override by php attribute #[Setup]
         ;
 
         /** @var SetupClassByAttribute $class */
@@ -128,7 +128,7 @@ class SetupTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupByAttributeWithArgumentAsReference::class))
-            ->setup('setSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setup('setSomeClassAsContainerIdentifier', ['someClass' => null]) // overrode by php attribute on method
             ->setContainer($mockContainer)
         ;
 

--- a/tests/FromDocs/PhpDefinitions/SetupDefinitionTest.php
+++ b/tests/FromDocs/PhpDefinitions/SetupDefinitionTest.php
@@ -35,9 +35,9 @@ class SetupDefinitionTest extends TestCase
         $definitions = [
             'services.lite' => diAutowire(LiteDependency::class),
             diAutowire(RulesWithSetter::class, true)
-                ->setup('addRule', rule: diGet(RuleB::class))
-                ->setup('addRule', rule: diGet(RuleC::class))
-                ->setup('addRule', diGet('services.lite'), diGet(RuleA::class)),
+                ->setup('addRule', ['rule' => diGet(RuleB::class)])
+                ->setup('addRule', ['rule' => diGet(RuleC::class)])
+                ->setup('addRule', [diGet('services.lite'), diGet(RuleA::class)]),
         ];
 
         $container = (new DiContainerFactory())->make($definitions);


### PR DESCRIPTION
Новая сигнатура для:
- `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionConfigAutowireInterface::setup()`
- `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionConfigAutowireInterface::setupImmutable()`

⚠️ Ломает обратную совместимость.

Необходимо заменить параметр `mixed ...$argument` на `array $arguments` в конфигурировании определений в стиле php.

Для аргументов передаваемых по индексу:
```diff
-   ->setup('setAttribute', \PDO::ATTR_CASE, \PDO::CASE_UPPER)
+   ->setup('setAttribute', [\PDO::ATTR_CASE, \PDO::CASE_UPPER])
```
Для именованных аргументов:
```diff
-   ->setupImmutable('withSomeClass', someClass: null)
+   ->setupImmutable('withSomeClass', ['someClass' => null])
```