### PR TITLE
 Arguments for setup() and setupImmutable() methods that configured DiDefinitionAutowire()

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -30,7 +30,7 @@ return static function (): \Generator {
                 dsn: 'sqlite:/tmp/my.db'
             )
             // Вызвать метод "setAttribute" и предать параметры в него
-            ->setup('setAttribute', \PDO::ATTR_CASE, \PDO::CASE_UPPER),
+            ->setup('setAttribute', [\PDO::ATTR_CASE, \PDO::CASE_UPPER]),
 
 };
 ```
@@ -180,7 +180,7 @@ diAutowire(...)->bindArguments(var1: 'value 1', var2: 'value 2')
 
 **Дополнительная настройка сервиса через методы класса (mutable setters):**
 ```php 
-setup(string $method, mixed ...$argument)
+setup(string $method, array $arguments = [])
 ``` 
 Параметры:
 - `$method` – имя вызываемого метода в классе
@@ -197,7 +197,7 @@ setup(string $method, mixed ...$argument)
 
 Можно использовать именованные аргументы параметров:
 ```php
-diAutowire(...)->setup('classMethod', var1: 'value 1', var2: 'value 2')
+diAutowire(...)->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
 // $object->classMethod(string $var1, string $var2)
 ```
 Если в методе нет параметров или они могут быть разрешены автоматически, то аргументы указывать не нужно:
@@ -210,10 +210,10 @@ diAutowire(...)->setup('classMethod', var1: 'value 1', var2: 'value 2')
 При указании нескольких вызовов метода он будет вызван указанное количество раз и возможно с разными аргументами:
 ```php
 diAutowire(...)
-  ->setup('classMethod', var1: 'value 1', var2: 'value 2')
-  ->setup('classMethod', var1: 'value 3', var2: 'value 4')
-  // $object->classMethod('value 1', 'value 2');
-  // $object->classMethod('value 3', 'value 4');
+  ->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
+  ->setup('classMethod', ['var1' => 'value 3', 'var2' => 'value 4')]
+  // $object->classMethod(var1: 'value 1', var2: 'value 2');
+  // $object->classMethod(var1: 'value 3', var2: 'value 4');
 ```
  
 > [!NOTE]
@@ -221,11 +221,11 @@ diAutowire(...)
 
 **Дополнительная настройка сервиса через методы класса возвращающие значение (immutable setters):**
 ```php 
-setupImmutable(string $method, mixed ...$argument)
+setupImmutable(string $method, array $arguments = [])
 ``` 
 Параметры:
 - `$method` – имя вызываемого метода в классе
-- `$argument` – аргументы к параметрам метода класса
+- `$arguments` – аргументы к параметрам метода класса
 
 Возвращаемое значение метода должно быть `self`, `static`
 или того же класса, что и сам php класс.
@@ -1480,7 +1480,7 @@ use function Kaspi\DiContainer\diAutowire;
 return static function(): \Generator {
 
     yield 'priority_queue.get_data' => diAutowire(\SplPriorityQueue::class)
-        ->setup('setExtractFlags', \SplPriorityQueue::EXTR_DATA);
+        ->setup('setExtractFlags', [\SplPriorityQueue::EXTR_DATA]);
 
 };
 ```
@@ -1544,7 +1544,7 @@ return static function(): \Generator {
 
     yield diAutowire(App\SomeClass::class)
         // Будет возвращён объект из метода `withLogger`
-        ->setupImmutable('withLogger', diGet(App\Servces\FileLogger::class));
+        ->setupImmutable('withLogger', [diGet(App\Servces\FileLogger::class)]);
 };
 ```
 

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -91,18 +91,18 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
     /**
      * @return $this
      */
-    public function setup(string $method, mixed ...$argument): static
+    public function setup(string $method, array $arguments = []): static
     {
         unset($this->setupArgBuilders);
-        $this->setupInternal($method, ...$argument);
+        $this->setupInternal($method, $arguments);
 
         return $this;
     }
 
-    public function setupImmutable(string $method, mixed ...$argument): static
+    public function setupImmutable(string $method, array $arguments = []): static
     {
         unset($this->setupArgBuilders);
-        $this->setupImmutableInternal($method, ...$argument);
+        $this->setupImmutableInternal($method, $arguments);
 
         return $this;
     }

--- a/src/DiContainer/DiDefinition/DiDefinitionFactory.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionFactory.php
@@ -45,10 +45,10 @@ final class DiDefinitionFactory implements DiDefinitionFactoryInterface, DiDefin
      */
     public function __construct(private readonly string $definition, private readonly ?bool $isSingleton = null) {}
 
-    public function setup(string $method, mixed ...$argument): static
+    public function setup(string $method, array $arguments = []): static
     {
         unset($this->autowire);
-        $this->setupInternal($method, ...$argument);
+        $this->setupInternal($method, $arguments);
 
         return $this;
     }
@@ -61,10 +61,10 @@ final class DiDefinitionFactory implements DiDefinitionFactoryInterface, DiDefin
         return $this;
     }
 
-    public function setupImmutable(string $method, mixed ...$argument): static
+    public function setupImmutable(string $method, array $arguments = []): static
     {
         unset($this->autowire);
-        $this->setupImmutableInternal($method, ...$argument);
+        $this->setupImmutableInternal($method, $arguments);
 
         return $this;
     }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionSetupAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionSetupAutowireInterface.php
@@ -18,23 +18,23 @@ interface DiDefinitionSetupAutowireInterface extends DiDefinitionArgumentsInterf
      *
      * User can set arguments by named argument:
      *
-     *       ->setup('classMethod', var1: 'value 1', var2: 'value 2')
+     *       ->setup('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
      *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
      *
-     *       ->setup('classMethod', var1: new DiDefinitionGet('service.one'))
-     *       ->setup('classMethod', var1: new DiDefinitionGet('service.two'))
+     *       ->setup('classMethod', ['var1' => new DiDefinitionGet('service.one')])
+     *       ->setup('classMethod', [var1: new DiDefinitionGet('service.two')])
      *
      * User can set arguments by index argument:
      *
-     *      ->setup('classMethod', 'value 1', 'value 2')
+     *      ->setup('classMethod', ['value 1', 'value 2'])
      *      // bind parameters by index Class->classMethod('value 1', 'value 2')
      *
-     * @param non-empty-string         $method
-     * @param (DiDefinitionType|mixed) ...$argument
+     * @param non-empty-string                                                 $method
+     * @param array<non-empty-string|non-negative-int, DiDefinitionType|mixed> $arguments
      *
      * @return $this
      */
-    public function setup(string $method, mixed ...$argument): static;
+    public function setup(string $method, array $arguments = []): static;
 
     /**
      * Call immutable setter method for class with input arguments with return type aka self.
@@ -45,21 +45,21 @@ interface DiDefinitionSetupAutowireInterface extends DiDefinitionArgumentsInterf
      *
      * User can set arguments by named argument:
      *
-     *       ->setupImmutable('classMethod', var1: 'value 1', var2: 'value 2')
+     *       ->setupImmutable('classMethod', ['var1' => 'value 1', 'var2' => 'value 2'])
      *       // bind parameters by name Class->classMethod(var1: 'value 1', var2: 'value 2')
      *
-     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.one'))
-     *       ->setupImmutable('classMethod', var1: new DiDefinitionGet('service.two'))
+     *       ->setupImmutable('classMethod', ['var1' => new DiDefinitionGet('service.one')])
+     *       ->setupImmutable('classMethod', ['var1' => new DiDefinitionGet('service.two')])
      *
      * User can set arguments by index argument:
      *
-     *      ->setupImmutable('classMethod', 'value 1', 'value 2')
+     *      ->setupImmutable('classMethod', ['value 1', 'value 2'])
      *      // bind parameters by index Class->classMethod('value 1', 'value 2')
      *
-     * @param non-empty-string         $method
-     * @param (DiDefinitionType|mixed) ...$argument
+     * @param non-empty-string                                                 $method
+     * @param array<non-empty-string|non-negative-int, DiDefinitionType|mixed> $arguments
      *
      * @return $this
      */
-    public function setupImmutable(string $method, mixed ...$argument): static;
+    public function setupImmutable(string $method, array $arguments = []): static;
 }

--- a/src/DiContainer/Traits/SetupConfigureTrait.php
+++ b/src/DiContainer/Traits/SetupConfigureTrait.php
@@ -34,27 +34,23 @@ trait SetupConfigureTrait
     private array $setupByAttributes;
 
     /**
-     * @param non-empty-string $method
+     * @param non-empty-string            $method
+     * @param SetupConfigureArgumentsType $arguments
      */
-    public function setup(string $method, mixed ...$argument): static
+    public function setup(string $method, array $arguments = []): static
     {
-        /**
-         * @phpstan-var SetupConfigureArgumentsType $argument
-         */
-        $this->setup[$method][] = [SetupConfigureMethod::Mutable, $argument];
+        $this->setup[$method][] = [SetupConfigureMethod::Mutable, $arguments];
 
         return $this;
     }
 
     /**
-     * @param non-empty-string $method
+     * @param non-empty-string            $method
+     * @param SetupConfigureArgumentsType $arguments
      */
-    public function setupImmutable(string $method, mixed ...$argument): static
+    public function setupImmutable(string $method, array $arguments): static
     {
-        /**
-         * @phpstan-var SetupConfigureArgumentsType $argument
-         */
-        $this->setup[$method][] = [SetupConfigureMethod::Immutable, $argument];
+        $this->setup[$method][] = [SetupConfigureMethod::Immutable, $arguments];
 
         return $this;
     }
@@ -86,9 +82,9 @@ trait SetupConfigureTrait
         foreach ($this->setup as $method => $setups) {
             foreach ($setups as $setup) {
                 if (SetupConfigureMethod::Mutable === $setup[0]) {
-                    $definition->setup($method, ...$setup[1]);
+                    $definition->setup($method, $setup[1]);
                 } else {
-                    $definition->setupImmutable($method, ...$setup[1]);
+                    $definition->setupImmutable($method, $setup[1]);
                 }
             }
         }

--- a/tests/Compiler/CompilableDefinition/GetEntry/GetEntryTest.php
+++ b/tests/Compiler/CompilableDefinition/GetEntry/GetEntryTest.php
@@ -6,7 +6,6 @@ namespace Tests\Compiler\CompilableDefinition\GetEntry;
 
 use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
 use Kaspi\DiContainer\Compiler\CompiledEntry;
-use Kaspi\DiContainer\Compiler\DiContainerDefinitions;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\DiDefinitionException;

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupImmutableTest.php
@@ -165,7 +165,7 @@ class SetupImmutableTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupImmutableByAttribute::class))
-            ->setupImmutable('withSomeClass', someClass: diAutowire(SomeClass::class)->bindArguments('aaa'))
+            ->setupImmutable('withSomeClass', ['someClass' => diAutowire(SomeClass::class)->bindArguments('aaa')])
         ;
 
         $setupImmutableClass = $def->resolve($this->mockContainer);
@@ -188,7 +188,7 @@ class SetupImmutableTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupImmutableByAttributeWithArgumentAsDefinition::class))
-            ->setupImmutable('withSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setupImmutable('withSomeClassAsContainerIdentifier', ['someClass' => null]) // overrode by php attribute on method
         ;
 
         /** @var SetupImmutableByAttributeWithArgumentAsDefinition $class */
@@ -246,8 +246,10 @@ class SetupImmutableTest extends TestCase
         $def = (new DiDefinitionAutowire(Foo::class))
             ->setupImmutable(
                 'method',
-                diGet('services.secure_string'),
-                rule: diGet('services.rule_a')
+                [
+                    diGet('services.secure_string'),
+                    'rule' => diGet('services.rule_a'),
+                ]
             )
         ;
 

--- a/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/SetupTest.php
@@ -49,10 +49,10 @@ class SetupTest extends TestCase
         $mockContainer = $this->createMock(DiContainerInterface::class);
 
         $def = (new DiDefinitionAutowire(SetupClass::class))
-            ->setup('setName', newName: diValue('Vasiliy')) // first set name
-            ->setup('setName', diValue('Piter')) // override set name
-            ->setup('setParameters', paramName: diValue('key1'), parameters: ['One', 'Two', 'Three'])
-            ->setup('setParameters', 'key2', ['Four', 'Five', 'Six'])
+            ->setup('setName', ['newName' => diValue('Vasiliy')]) // first set name
+            ->setup('setName', [diValue('Piter')]) // override set name
+            ->setup('setParameters', ['paramName' => diValue('key1'), 'parameters' => ['One', 'Two', 'Three']])
+            ->setup('setParameters', ['key2', ['Four', 'Five', 'Six']])
         ;
 
         /**
@@ -105,8 +105,8 @@ class SetupTest extends TestCase
             ->setup('incInc')// override by php attribute #[Setup]
             ->setup('incInc') // override by php attribute #[Setup]
             ->setup('incInc') // override by php attribute #[Setup]
-            ->setup('setParameters', 'key1', ['One', 'Two', 'Three']) // override by php attribute #[Setup]
-            ->setup('setParameters', 'key2', ['X', 'Y', 'Z']) // override by php attribute #[Setup]
+            ->setup('setParameters', ['key1', ['One', 'Two', 'Three']]) // override by php attribute #[Setup]
+            ->setup('setParameters', ['key2', ['X', 'Y', 'Z']]) // override by php attribute #[Setup]
         ;
 
         /** @var SetupClassByAttribute $class */
@@ -142,7 +142,7 @@ class SetupTest extends TestCase
         ;
 
         $def = (new DiDefinitionAutowire(SetupByAttributeWithArgumentAsReference::class))
-            ->setup('setSomeClassAsContainerIdentifier', someClass: null) // overrode by php attribute on method
+            ->setup('setSomeClassAsContainerIdentifier', ['someClass' => null]) // overrode by php attribute on method
         ;
 
         /** @var SetupByAttributeWithArgumentAsReference $class */

--- a/tests/DiDefinition/DiDefinitionFactory/DiDefinitionFactoryTest.php
+++ b/tests/DiDefinition/DiDefinitionFactory/DiDefinitionFactoryTest.php
@@ -112,7 +112,7 @@ class DiDefinitionFactoryTest extends TestCase
         );
 
         $factory = new DiDefinitionFactory(Baz::class);
-        $factory->setupImmutable('withBar', diGet(Bar::class));
+        $factory->setupImmutable('withBar', [diGet(Bar::class)]);
 
         self::assertEquals(
             'ok Tests\DiDefinition\DiDefinitionFactory\Fixtures\Bar',
@@ -131,7 +131,7 @@ class DiDefinitionFactoryTest extends TestCase
         );
 
         $factory = new DiDefinitionFactory(Baz::class);
-        $factory->setup('setBar', diGet(Bar::class));
+        $factory->setup('setBar', [diGet(Bar::class)]);
 
         self::assertEquals(
             'ok Tests\DiDefinition\DiDefinitionFactory\Fixtures\Bar',

--- a/tests/FromDocs/PhpDefinitions/SetupDefinitionTest.php
+++ b/tests/FromDocs/PhpDefinitions/SetupDefinitionTest.php
@@ -28,12 +28,14 @@ class SetupDefinitionTest extends TestCase
             yield 'services.lite' => diAutowire(LiteDependency::class);
 
             yield diAutowire(RulesWithSetter::class, true)
-                ->setup('addRule', rule: diGet(RuleB::class))
-                ->setup('addRule', rule: diGet(RuleC::class))
+                ->setup('addRule', ['rule' => diGet(RuleB::class)])
+                ->setup('addRule', ['rule' => diGet(RuleC::class)])
                 ->setup(
                     'addRule',
-                    diGet('services.lite'),
-                    diGet(RuleA::class)
+                    [
+                        diGet('services.lite'),
+                        diGet(RuleA::class),
+                    ]
                 )
             ;
         };


### PR DESCRIPTION
Новая сигнатура для:
- `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface::setup()`
- `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface::setupImmutable()`

⚠️ Ломает обратную совместимость.

Необходимо заменить параметр `mixed ...$argument` на `array $arguments` в конфигурировании определений в стиле php.

Для аргументов передаваемых по индексу:
```diff
-   ->setup('setAttribute', \PDO::ATTR_CASE, \PDO::CASE_UPPER)
+   ->setup('setAttribute', [\PDO::ATTR_CASE, \PDO::CASE_UPPER])
```
Для именованных аргументов:
```diff
-   ->setupImmutable('withSomeClass', someClass: null)
+   ->setupImmutable('withSomeClass', ['someClass' => null])
```