### PR TITLE
`DeferredSourceDefinitionsMutable::__construct()` pass `Closure` type.

### DIFF
--- a/src/DiContainer/DiContainerBuilder.php
+++ b/src/DiContainer/DiContainerBuilder.php
@@ -195,7 +195,7 @@ final class DiContainerBuilder implements DiContainerBuilderInterface
             }
         }
 
-        $container = new DiContainer(new DeferredSourceDefinitionsMutable($this->definitions()), $this->containerConfig);
+        $container = new DiContainer(new DeferredSourceDefinitionsMutable(fn () => $this->definitions()), $this->containerConfig);
         $diContainerDefinitions = new DiContainerDefinitions($container, new IdsIterator());
 
         if (!isset($this->compilerDiDefinitionTransformer)) {

--- a/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\SourceDefinitions;
 
+use Closure;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 
 final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMutable
@@ -12,16 +13,16 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
     private array $definitions;
 
     /**
-     * @param iterable<non-empty-string|non-negative-int, mixed> $sourceDefinitions
+     * @param Closure(): iterable<non-empty-string|non-negative-int, mixed> $sourceDefinitions
      */
-    public function __construct(private iterable $sourceDefinitions) {}
+    public function __construct(private Closure $sourceDefinitions) {}
 
     protected function &definitions(): array
     {
         if (!isset($this->definitions)) {
             $this->definitions = [];
 
-            foreach ($this->sourceDefinitions as $identifier => $sourceDefinition) {
+            foreach (($this->sourceDefinitions)() as $identifier => $sourceDefinition) {
                 $this->offsetSet($identifier, $sourceDefinition);
             }
 

--- a/tests/DiContainer/Constructor/DiContainerAddDefinitionThroughConstructorTest.php
+++ b/tests/DiContainer/Constructor/DiContainerAddDefinitionThroughConstructorTest.php
@@ -83,7 +83,7 @@ class DiContainerAddDefinitionThroughConstructorTest extends TestCase
 
     public function testDefinitionsAsDeferredSourceDefinitionsMutable(): void
     {
-        $definitions = new DeferredSourceDefinitionsMutable(['service.foo' => null]);
+        $definitions = new DeferredSourceDefinitionsMutable(static fn (): iterable => ['service.foo' => null]);
 
         self::assertTrue((new DiContainer(definitions: $definitions))->has('service.foo'));
     }


### PR DESCRIPTION
Resolve #472 
