### PR TITLE
Runtime parameter

### DIFF
--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -89,6 +89,7 @@ var_dump(
   - [diTaggedAs](#ditaggedas) – тегированные определения
   - [diFactory](#difactory) – фабрика для разрешения зависимости
   - [diParameter](#diparameter) – параметр контейнера
+  - [diParameterRuntime](#diparameterruntime) – параметр контейнера времени исполнения
 
 > [!TIP]
 > ✅ Для параметров методов php классов или `callable` типов можно указывать [скалярные типы](https://www.php.net/manual/ru/language.types.type-system.php#language.types.type-system.atomic.scalar),
@@ -818,6 +819,25 @@ diParameter(string $name = ''): DiDefinitionNoArgumentsInterface
 
 > [!NOTE]
 > Подробное [описание работы с параметрами контейнера](09-container-parameters.md).
+
+#### diParameterRuntime
+Параметр контейнера времени исполнения. [Аналогичен хелпер функции `diParameter`](#diparameter), но значение необходимо установить в контейнер
+после его формирования.
+
+Сигнатура функции:
+```php
+use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use function \Kaspi\DiContainer\diParameterRuntime;
+
+diParameterRuntime(string $name = '', ?string $message = nul): DiDefinitionNoArgumentsInterface
+```
+
+Параметры:
+- `$name` – имя параметра контейнера.
+- `$message` – дополнительное сообщение, если параметр контейнера еще не определен.
+
+> [!NOTE]
+> Подробное [описание работы с параметрами контейнера](09-container-parameters.md#параметры-контейнера-определяемые-во-время-выполнения).
 
 ## Получение класса по интерфейсу
 

--- a/docs/02-attribute-definition.md
+++ b/docs/02-attribute-definition.md
@@ -26,6 +26,7 @@
 - **[Tag](#tag)** – определение тегов для класса.
 - **[TaggedAs](#taggedas)** – внедрение тегированных определений в параметры конструктора, метода PHP класса.
 - **[Parameter](#parameter)** – разрешение зависимости через «параметр контейнера».
+- **[ParameterRuntime](#parameterruntime)** – разрешение зависимости через «параметр контейнера времени исполнения».
 - **[Параметр переменной длины](#параметр-переменной-длины)** – особенности применения атрибутов.
 
 ## Autowire
@@ -1152,7 +1153,7 @@ class AnyService {
 namespace App\Services;
 
 use App\Services\Qux;
-use Kaspi\DiContainer\Attributes\{Inject, Parameter};
+use Kaspi\DiContainer\Attributes\Parameter;
 
 final class Foo {
     public function __construct(
@@ -1165,6 +1166,40 @@ final class Foo {
 
 > [!NOTE]
 > Подробное [описание работы с параметрами контейнера](09-container-parameters.md).
+
+## ParameterRuntime
+Параметр контейнера времени исполнения. [Аналогичен PHP атрибуту `Parameter`](#parameter), но значение необходимо установить в контейнер
+после его формирования.
+
+Сигнатура php атрибута:
+```php
+#[ParameterRuntime(string $name = '', ?string $message = null)]
+```
+Параметры:
+- `$name` – имя параметра контейнера.
+- `$message` – дополнительное сообщение, если параметр контейнера еще не определен.
+
+> [!NOTE]
+> Атрибут может быть применен несколько раз к параметрам переменной длины (_variadic parameter_).
+
+```php
+namespace App\Services;
+
+use App\Services\Qux;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
+
+final class Bar {
+    public function __construct(
+        private Qux $qux,
+        #[ParameterRuntime('foo.parameter')]
+        private string $value,
+    ) {}
+}
+```
+
+> [!NOTE]
+> Подробное [описание работы с параметрами контейнера](09-container-parameters.md#параметры-контейнера-определяемые-во-время-выполнения).
+
 
 ## Параметр переменной длины.
 При разрешении зависимостей параметра переменной длины у метода или функции можно использовать

--- a/docs/09-container-parameters.md
+++ b/docs/09-container-parameters.md
@@ -389,3 +389,63 @@ final class Foo {
     ) {}
 }
 ```
+## Параметры контейнера определяемые во время выполнения.
+Некоторые параметры контейнера нельзя определить в конфигурационных файлах,
+поскольку значение параметра вычисляется во время выполнения с использованием зависимостей контейнера.
+
+Для [компилируемого контейнера](06-container-builder.md#компиляция-контейнера) важно дать знать о будущем существовании «параметра контейнера».
+Для таких случаев есть определение «параметра контейнера времени исполнения».
+
+### Хелпер функция diParameterRuntime.
+Хелпер функция `diParameterRuntime` используется при [конфигурировании контейнера как php определений](01-php-definition.md#diparameterruntime).
+
+### PHP атрибут ParameterRuntime.
+Php атрибут `ParameterRuntime` необходимо использовать при [конфигурации определений через PHP атрибуты](02-attribute-definition.md#parameterruntime).
+
+### Пример использования «параметра контейнера времени исполнения».
+```php
+namespace App\Services;
+
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
+
+final class Foo {
+    public function __construct(private string $qux) {}
+}
+
+final class Bar {
+    public function __construct(
+        #[ParameterRuntime('baz')]
+        private string $qux
+    ) {}
+}
+```
+```php
+use App\Services\{Foo, Bar};
+use Kaspi\DiContainer\DiContainerBuilder;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', src: '/app/src/')
+    ->load('/app/config/services.php')
+    ->build()
+;
+
+// некая функция `doCalculate()` вычисляет значение
+// и возвращает строку `'random_string'`  
+$calculatedString = doCalcualte();
+
+// 🚩 Установка параметра контейнера 'foo' и его значения
+// в уже сформированный контейнер зависимостей (runtime container)
+$container->parameters()
+    ->set('baz', $calculatedString);
+
+$fooClass = $container->get(Foo::class);
+$barClass = $container->get(Bar::class);
+```
+> [!NOTE]
+> При разрешении параметров конструктора класса `App\Services\Foo`
+> в свойстве `App\Services\Foo::$qux` будет значение `'random_string'`
+> полученное на основе конфигурации через хелпер функцию `diParameterRuntime`.
+> 
+> При разрешении параметров конструктора класса `App\Services\Bar`
+> в свойстве `App\Services\Bar::$qux` будет значение `'random_string'`
+> полученное на основе конфигурации через PHP атрибут `ParameterRuntime`.

--- a/src/DiContainer/AttributeReader.php
+++ b/src/DiContainer/AttributeReader.php
@@ -11,6 +11,7 @@ use Kaspi\DiContainer\Attributes\DiFactory;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
 use Kaspi\DiContainer\Attributes\Parameter;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
 use Kaspi\DiContainer\Attributes\ProxyClosure;
 use Kaspi\DiContainer\Attributes\Service;
 use Kaspi\DiContainer\Attributes\Setup;
@@ -166,13 +167,13 @@ final class AttributeReader
     }
 
     /**
-     * @return Generator<DiFactory|Inject|InjectByCallable|Parameter|ProxyClosure|TaggedAs>
+     * @return Generator<DiFactory|Inject|InjectByCallable|Parameter|ParameterRuntime|ProxyClosure|TaggedAs>
      *
      * @throws AutowireAttributeException|AutowireParameterTypeException
      */
     public static function getAttributeOnParameter(ReflectionParameter $param, ContainerInterface $container): Generator
     {
-        $supportAttrs = [DiFactory::class, Inject::class, InjectByCallable::class, ProxyClosure::class, TaggedAs::class, Parameter::class];
+        $supportAttrs = [DiFactory::class, Inject::class, InjectByCallable::class, ProxyClosure::class, TaggedAs::class, Parameter::class, ParameterRuntime::class];
 
         $attrs = array_filter($param->getAttributes(), static fn (ReflectionAttribute $attr) => in_array($attr->getName(), $supportAttrs, true));
 
@@ -206,7 +207,7 @@ final class AttributeReader
                     );
                 }
             } else {
-                /** @var ReflectionAttribute<DiFactory|Parameter|ProxyClosure|TaggedAs> $attr */
+                /** @var ReflectionAttribute<DiFactory|Parameter|ParameterRuntime|ProxyClosure|TaggedAs> $attr */
                 $attrInit = $attr->newInstance();
             }
 

--- a/src/DiContainer/Attributes/ParameterRuntime.php
+++ b/src/DiContainer/Attributes/ParameterRuntime.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+final class ParameterRuntime
+{
+    public function __construct(public readonly string $name = '', public readonly ?string $message = null) {}
+}

--- a/src/DiContainer/Compiler/CompilableDefinition/ParameterRuntimeEntry.php
+++ b/src/DiContainer/Compiler/CompilableDefinition/ParameterRuntimeEntry.php
@@ -8,6 +8,7 @@ use Kaspi\DiContainer\Compiler\CompiledEntry;
 use Kaspi\DiContainer\Exception\DefinitionCompileException;
 use Kaspi\DiContainer\Interfaces\Compiler\CompilableDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\CompiledEntryInterface;
+use Kaspi\DiContainer\Interfaces\Compiler\DiContainerDefinitionsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 
 use function is_string;
@@ -19,11 +20,18 @@ final class ParameterRuntimeEntry implements CompilableDefinitionInterface
 {
     public function __construct(
         private readonly DiDefinitionParameterRuntimeInterface $parameter,
+        private readonly DiContainerDefinitionsInterface $diContainerDefinitions,
     ) {}
 
     public function compile(string $containerVar, array $scopeVars = [], mixed $context = null): CompiledEntryInterface
     {
         $parameterName = $this->getParameterName();
+
+        if ($this->diContainerDefinitions->getContainer()->parameters()->has($parameterName)) {
+            throw new DefinitionCompileException(
+                sprintf('The container\'s runtime parameter "%s" must be set in the container at runtime. Use the DiContainerInterface::parameters()->set() method.', $parameterName)
+            );
+        }
 
         $compiledEntry = new CompiledEntry(
             scopeServiceVar: '$parameters',

--- a/src/DiContainer/Compiler/CompilableDefinition/ParameterRuntimeEntry.php
+++ b/src/DiContainer/Compiler/CompilableDefinition/ParameterRuntimeEntry.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Compiler\CompilableDefinition;
+
+use Kaspi\DiContainer\Compiler\CompiledEntry;
+use Kaspi\DiContainer\Exception\DefinitionCompileException;
+use Kaspi\DiContainer\Interfaces\Compiler\CompilableDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\Compiler\CompiledEntryInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
+
+use function is_string;
+use function rtrim;
+use function sprintf;
+use function var_export;
+
+final class ParameterRuntimeEntry implements CompilableDefinitionInterface
+{
+    public function __construct(
+        private readonly DiDefinitionParameterRuntimeInterface $parameter,
+    ) {}
+
+    public function compile(string $containerVar, array $scopeVars = [], mixed $context = null): CompiledEntryInterface
+    {
+        $parameterName = $this->getParameterName();
+
+        $compiledEntry = new CompiledEntry(
+            scopeServiceVar: '$parameters',
+            scopeVars: [...$scopeVars, $containerVar],
+        );
+        $compiledEntry->addToStatements(
+            sprintf('%s = %s->parameters()', $compiledEntry->getScopeServiceVar(), $containerVar)
+        );
+        $exceptionMessage = rtrim(
+            sprintf('The container parameter "%s" must be set in the container at runtime. %s', $parameterName, $this->parameter->getMessage())
+        );
+
+        $exceptionExpression = sprintf('throw new \Kaspi\DiContainer\Exception\ParameterNotFoundException(%s)', var_export($exceptionMessage, true));
+
+        $compiledEntry->addToStatements(
+            sprintf('if (!%s->has(%s)) %s', $compiledEntry->getScopeServiceVar(), var_export($this->getParameterName(), true), $exceptionExpression)
+        );
+
+        $compiledEntry->setExpression(
+            sprintf('%s->get(%s)', $compiledEntry->getScopeServiceVar(), var_export($this->getParameterName(), true))
+        );
+
+        return $compiledEntry;
+    }
+
+    public function getDiDefinition(): DiDefinitionParameterRuntimeInterface
+    {
+        return $this->parameter;
+    }
+
+    /**
+     * @return non-empty-string
+     *
+     * @throws DefinitionCompileException
+     */
+    private function getParameterName(): string
+    {
+        if ('' !== $this->parameter->getDefinition()) {
+            return $this->parameter->getDefinition();
+        }
+
+        if (is_string($this->parameter->getContext()) && '' !== $this->parameter->getContext()) {
+            return $this->parameter->getContext();
+        }
+
+        throw new DefinitionCompileException(
+            'Cannot compile container parameter runtime definition. Parameter name must be non-empty string.'
+        );
+    }
+}

--- a/src/DiContainer/Compiler/DiDefinitionTransformer.php
+++ b/src/DiContainer/Compiler/DiDefinitionTransformer.php
@@ -71,7 +71,7 @@ final class DiDefinitionTransformer implements DiDefinitionTransformerInterface
         }
 
         if ($definition instanceof DiDefinitionParameterRuntimeInterface) {
-            return new ParameterRuntimeEntry($definition);
+            return new ParameterRuntimeEntry($definition, $diContainerDefinitions);
         }
 
         if (null !== $fallback) {

--- a/src/DiContainer/Compiler/DiDefinitionTransformer.php
+++ b/src/DiContainer/Compiler/DiDefinitionTransformer.php
@@ -10,6 +10,7 @@ use Kaspi\DiContainer\Compiler\CompilableDefinition\FactoryEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ObjectEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterEntry;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterRuntimeEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ProxyClosureEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\TaggedAsEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ValueEntry;
@@ -22,6 +23,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionCallableInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionFactoryInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionLinkInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionProxyClosureInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionValueInterface;
@@ -66,6 +68,10 @@ final class DiDefinitionTransformer implements DiDefinitionTransformerInterface
 
         if ($definition instanceof DiDefinitionParameterInterface) {
             return new ParameterEntry($definition, $diContainerDefinitions);
+        }
+
+        if ($definition instanceof DiDefinitionParameterRuntimeInterface) {
+            return new ParameterRuntimeEntry($definition);
         }
 
         if (null !== $fallback) {

--- a/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
+++ b/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
@@ -9,12 +9,14 @@ use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\Attributes\DiFactory;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
+use Kaspi\DiContainer\Attributes\Parameter;
 use Kaspi\DiContainer\Attributes\ProxyClosure;
 use Kaspi\DiContainer\Attributes\TaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Exception\ArgumentBuilderException;
@@ -26,6 +28,7 @@ use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\Arguments\ArgumentBuilderInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
@@ -298,7 +301,7 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
     }
 
     /**
-     * @return Generator<(DiDefinitionCallable|DiDefinitionFactory|DiDefinitionGet|DiDefinitionParameter|DiDefinitionProxyClosure|DiDefinitionTaggedAs)>
+     * @return Generator<(DiDefinitionCallable|DiDefinitionFactory|DiDefinitionGet|DiDefinitionParameter|DiDefinitionParameterRuntime|DiDefinitionProxyClosure|DiDefinitionTaggedAs)>
      *
      * @throws AutowireAttributeException|AutowireParameterTypeException
      */
@@ -332,8 +335,12 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
                 ;
             } elseif ($attr instanceof InjectByCallable) {
                 $definition = new DiDefinitionCallable($attr->getCallable());
-            } else {
+            } elseif ($attr instanceof Parameter) {
                 $definition = (new DiDefinitionParameter($attr->name))
+                    ->setContext('' === $attr->name ? $param->name : null)
+                ;
+            } else {
+                $definition = (new DiDefinitionParameterRuntime($attr->name, $attr->message))
                     ->setContext('' === $attr->name ? $param->name : null)
                 ;
             }
@@ -344,7 +351,10 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
 
     private function setContainerParameterContext(int|string $argKey, mixed $definition, ReflectionParameter $param): void
     {
-        if (!($definition instanceof DiDefinitionParameterInterface) || '' !== $definition->getDefinition()) {
+        $isParameterType = $definition instanceof DiDefinitionParameterInterface
+            || $definition instanceof DiDefinitionParameterRuntimeInterface;
+
+        if (!$isParameterType || '' !== $definition->getDefinition()) {
             return;
         }
 

--- a/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
+++ b/src/DiContainer/DiDefinition/Arguments/ArgumentBuilder.php
@@ -27,8 +27,7 @@ use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\Arguments\ArgumentBuilderInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterWithContextInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
@@ -351,10 +350,7 @@ final class ArgumentBuilder implements ArgumentBuilderInterface
 
     private function setContainerParameterContext(int|string $argKey, mixed $definition, ReflectionParameter $param): void
     {
-        $isParameterType = $definition instanceof DiDefinitionParameterInterface
-            || $definition instanceof DiDefinitionParameterRuntimeInterface;
-
-        if (!$isParameterType || '' !== $definition->getDefinition()) {
+        if (!($definition instanceof DiDefinitionParameterWithContextInterface) || '' !== $definition->getDefinition()) {
             return;
         }
 

--- a/src/DiContainer/DiDefinition/DiDefinitionParameter.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionParameter.php
@@ -4,20 +4,13 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\DiDefinition;
 
-use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterInterface;
 use UnitEnum;
 
-use function get_debug_type;
-use function is_string;
-use function sprintf;
-
-final class DiDefinitionParameter implements DiDefinitionNoArgumentsInterface, DiDefinitionParameterInterface
+final class DiDefinitionParameter extends DiDefinitionParameterWithContextAbstract implements DiDefinitionNoArgumentsInterface, DiDefinitionParameterInterface
 {
-    private ?string $context = null;
-
     public function __construct(private readonly string $name = '') {}
 
     public function getDefinition(): string
@@ -25,34 +18,10 @@ final class DiDefinitionParameter implements DiDefinitionNoArgumentsInterface, D
         return $this->name;
     }
 
-    public function getContext(): ?string
-    {
-        return $this->context;
-    }
-
-    public function setContext(?string $context): static
-    {
-        $this->context = $context;
-
-        return $this;
-    }
-
     public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null
     {
-        if ('' !== $this->name) {
-            return $container->parameters()->get($this->name);
-        }
-
-        if (null !== $this->context && '' !== $this->context) {
-            return $container->parameters()->get($this->context);
-        }
-
-        if (is_string($context) && '' !== $context) {
-            return $container->parameters()->get($context);
-        }
-
-        throw new DiDefinitionException(
-            sprintf('Parameter name must be non-empty string. Parameter name my be set as $context in DiDefinitionParameter::resolve() or in DiDefinitionParameter::setContext(). Current $context type "%s".', get_debug_type($context))
-        );
+        return $container->parameters()
+            ->get($this->nameWithContext($context))
+        ;
     }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
@@ -10,26 +10,18 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use UnitEnum;
 
-use function get_debug_type;
-use function is_string;
 use function rtrim;
 use function sprintf;
 
-final class DiDefinitionParameterRuntime implements DiDefinitionParameterRuntimeInterface, DiDefinitionNoArgumentsInterface
+final class DiDefinitionParameterRuntime extends DiDefinitionParameterWithContextAbstract implements DiDefinitionParameterRuntimeInterface, DiDefinitionNoArgumentsInterface
 {
-    private ?string $context = null;
     private readonly string $message;
 
     public function __construct(
         private readonly string $name = '',
         ?string $message = null,
     ) {
-        $this->message = $message ?? 'Did you forget to define it?';
-    }
-
-    public function getContext(): ?string
-    {
-        return $this->context;
+        $this->message = $message ?? 'Did you forget to define it? Define parameter using method DiContainerInterface::parameters()->set()';
     }
 
     public function getDefinition(): string
@@ -46,42 +38,14 @@ final class DiDefinitionParameterRuntime implements DiDefinitionParameterRuntime
     {
         $parameterName = $this->nameWithContext($context);
 
-        if ('' === $parameterName) {
-            throw new DiDefinitionException(
-                sprintf('Parameter name must be non-empty string. Parameter name my be set as $context in DiDefinitionParameter::resolve() or in DiDefinitionParameter::setContext(). Current $context type "%s".', get_debug_type($context))
-            );
-        }
-
         if (!$container->parameters()->has($parameterName)) {
             throw new DiDefinitionException(
                 rtrim(
-                    sprintf('The container parameter "%s" must be set in the container at runtime using DiContainerInterface::parameters(). %s', $parameterName, $this->message)
+                    sprintf('The container parameter "%s" must be set in the container at runtime. %s', $parameterName, $this->message)
                 )
             );
         }
 
         return $container->parameters()->get($parameterName);
-    }
-
-    public function setContext(?string $context): static
-    {
-        $this->context = $context;
-
-        return $this;
-    }
-
-    private function nameWithContext(mixed $context): string
-    {
-        if ('' !== $this->name) {
-            return $this->name;
-        }
-
-        if (is_string($this->context) && '' !== $this->context) {
-            return $this->context;
-        }
-
-        return is_string($context) && '' !== $context
-            ? $context
-            : '';
     }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
@@ -21,7 +21,7 @@ final class DiDefinitionParameterRuntime extends DiDefinitionParameterWithContex
         private readonly string $name = '',
         ?string $message = null,
     ) {
-        $this->message = $message ?? 'Did you forget to define it? Define parameter using method DiContainerInterface::parameters()->set()';
+        $this->message = $message ?? 'Did you forget to define it? Define parameter using method DiContainerInterface::parameters()->set().';
     }
 
     public function getDefinition(): string

--- a/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionParameterRuntime.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\DiDefinition;
+
+use Kaspi\DiContainer\Exception\DiDefinitionException;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
+use UnitEnum;
+
+use function get_debug_type;
+use function is_string;
+use function rtrim;
+use function sprintf;
+
+final class DiDefinitionParameterRuntime implements DiDefinitionParameterRuntimeInterface, DiDefinitionNoArgumentsInterface
+{
+    private ?string $context = null;
+    private readonly string $message;
+
+    public function __construct(
+        private readonly string $name = '',
+        ?string $message = null,
+    ) {
+        $this->message = $message ?? 'Did you forget to define it?';
+    }
+
+    public function getContext(): ?string
+    {
+        return $this->context;
+    }
+
+    public function getDefinition(): string
+    {
+        return $this->name;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null
+    {
+        $parameterName = $this->nameWithContext($context);
+
+        if ('' === $parameterName) {
+            throw new DiDefinitionException(
+                sprintf('Parameter name must be non-empty string. Parameter name my be set as $context in DiDefinitionParameter::resolve() or in DiDefinitionParameter::setContext(). Current $context type "%s".', get_debug_type($context))
+            );
+        }
+
+        if (!$container->parameters()->has($parameterName)) {
+            throw new DiDefinitionException(
+                rtrim(
+                    sprintf('The container parameter "%s" must be set in the container at runtime using DiContainerInterface::parameters(). %s', $parameterName, $this->message)
+                )
+            );
+        }
+
+        return $container->parameters()->get($parameterName);
+    }
+
+    public function setContext(?string $context): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    private function nameWithContext(mixed $context): string
+    {
+        if ('' !== $this->name) {
+            return $this->name;
+        }
+
+        if (is_string($this->context) && '' !== $this->context) {
+            return $this->context;
+        }
+
+        return is_string($context) && '' !== $context
+            ? $context
+            : '';
+    }
+}

--- a/src/DiContainer/DiDefinition/DiDefinitionParameterWithContextAbstract.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionParameterWithContextAbstract.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\DiDefinition;
+
+use Kaspi\DiContainer\Exception\DiDefinitionException;
+
+use function get_debug_type;
+use function is_string;
+use function sprintf;
+
+abstract class DiDefinitionParameterWithContextAbstract
+{
+    protected ?string $context = null;
+
+    public function setContext(?string $context): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    public function getContext(): ?string
+    {
+        return $this->context;
+    }
+
+    abstract public function getDefinition(): string;
+
+    /**
+     * @return non-empty-string
+     *
+     * @throws DiDefinitionException
+     */
+    protected function nameWithContext(mixed $context): string
+    {
+        if ('' !== $this->getDefinition()) {
+            return $this->getDefinition();
+        }
+
+        if (is_string($this->context) && '' !== $this->context) {
+            return $this->context;
+        }
+
+        if (is_string($context) && '' !== $context) {
+            return $context;
+        }
+
+        throw new DiDefinitionException(
+            sprintf('Parameter name must be non-empty string. Parameter name my be set as $context in DiDefinitionParameter::resolve() or in DiDefinitionParameter::setContext(). Current $context type "%s".', get_debug_type($context))
+        );
+    }
+}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterInterface.php
@@ -4,38 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 
-use Kaspi\DiContainer\Interfaces\DiContainerInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ParameterExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
-use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
-use UnitEnum;
-
 /**
  * Container parameter.
- *
- * @phpstan-import-type SourceParameterType from SourceParametersMutableInterface
  */
-interface DiDefinitionParameterInterface extends DiDefinitionInterface
-{
-    /**
-     * Parameter name.
-     */
-    public function getDefinition(): string;
-
-    public function getContext(): ?string;
-
-    /**
-     * When the parameter name is not defined, $context will provide the container parameter name.
-     */
-    public function setContext(?string $context): static;
-
-    /**
-     * @return SourceParameterType
-     *
-     * @throws ParameterExceptionInterface
-     * @throws ParameterNotFoundExceptionInterface
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null;
-}
+interface DiDefinitionParameterInterface extends DiDefinitionParameterWithContextInterface {}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
@@ -4,49 +4,16 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 
-use Kaspi\DiContainer\Interfaces\DiContainerInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ParameterExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
-use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
-use UnitEnum;
-
 /**
  * The container parameter must be set in the container at runtime.
  *
  * Any container parameter cannot be defined in configuration files,
  * because value parameter calculate at runtime using container dependencies.
- *
- * @phpstan-import-type SourceParameterType from SourceParametersMutableInterface
  */
-interface DiDefinitionParameterRuntimeInterface extends DiDefinitionInterface
+interface DiDefinitionParameterRuntimeInterface extends DiDefinitionParameterWithContextInterface
 {
     /**
      * Additional message if the container parameter has not been defined yet.
      */
     public function getMessage(): string;
-
-    /**
-     * Parameter name.
-     */
-    public function getDefinition(): string;
-
-    /**
-     * Alternative container parameter name.
-     */
-    public function getContext(): ?string;
-
-    /**
-     * When the parameter name is not defined, $context will provide the container parameter name.
-     */
-    public function setContext(?string $context): static;
-
-    /**
-     * @return SourceParameterType
-     *
-     * @throws ParameterExceptionInterface
-     * @throws ParameterNotFoundExceptionInterface
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ParameterExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
+use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
+use UnitEnum;
+
+/**
+ * The container parameter must be set in the container at runtime.
+ *
+ * Any container parameter cannot be defined in configuration files,
+ * because value parameter calculate at runtime using container dependencies.
+ *
+ * @phpstan-import-type SourceParameterType from SourceParametersMutableInterface
+ */
+interface DiDefinitionParameterRuntimeInterface extends DiDefinitionInterface
+{
+    /**
+     * Additional message if the container parameter has not been defined yet.
+     */
+    public function getMessage(): string;
+
+    /**
+     * Parameter name.
+     */
+    public function getDefinition(): string;
+
+    /**
+     * Alternative container parameter name.
+     */
+    public function getContext(): ?string;
+
+    /**
+     * When the parameter name is not defined, $context will provide the container parameter name.
+     */
+    public function setContext(?string $context): static;
+
+    /**
+     * @return SourceParameterType
+     *
+     * @throws ParameterExceptionInterface
+     * @throws ParameterNotFoundExceptionInterface
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null;
+}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterRuntimeInterface.php
@@ -7,7 +7,7 @@ namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 /**
  * The container parameter must be set in the container at runtime.
  *
- * Any container parameter cannot be defined in configuration files,
+ * Some a container parameter cannot be defined in configuration files,
  * because value parameter calculate at runtime using container dependencies.
  */
 interface DiDefinitionParameterRuntimeInterface extends DiDefinitionParameterWithContextInterface

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterWithContextInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionParameterWithContextInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ParameterExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
+use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
+use UnitEnum;
+
+/**
+ * Container parameter.
+ *
+ * @phpstan-import-type SourceParameterType from SourceParametersMutableInterface
+ */
+interface DiDefinitionParameterWithContextInterface extends DiDefinitionInterface
+{
+    /**
+     * Parameter name.
+     */
+    public function getDefinition(): string;
+
+    /**
+     * Alternative container parameter name.
+     */
+    public function getContext(): ?string;
+
+    /**
+     * When the parameter name is not defined, $context will provide the container parameter name.
+     */
+    public function setContext(?string $context): static;
+
+    /**
+     * @return SourceParameterType
+     *
+     * @throws ParameterExceptionInterface
+     * @throws ParameterNotFoundExceptionInterface
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function resolve(DiContainerInterface $container, mixed $context = null): array|bool|float|int|string|UnitEnum|null;
+}

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -9,6 +9,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
@@ -92,5 +93,12 @@ if (!function_exists('Kaspi\DiContainer\diParameter')) { // @codeCoverageIgnore
     function diParameter(string $name = ''): DiDefinitionNoArgumentsInterface
     {
         return new DiDefinitionParameter($name);
+    }
+} // @codeCoverageIgnore
+
+if (!function_exists('Kaspi\DiContainer\diParameterRuntime')) { // @codeCoverageIgnore
+    function diParameterRuntime(string $name = '', ?string $message = null): DiDefinitionNoArgumentsInterface
+    {
+        return new DiDefinitionParameterRuntime($name, $message);
     }
 } // @codeCoverageIgnore

--- a/tests/AttributeReader/AttributeOnParameter/AttributeOnParameterTest.php
+++ b/tests/AttributeReader/AttributeOnParameter/AttributeOnParameterTest.php
@@ -9,6 +9,8 @@ use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\Attributes\DiFactory;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
+use Kaspi\DiContainer\Attributes\Parameter;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
 use Kaspi\DiContainer\Attributes\ProxyClosure;
 use Kaspi\DiContainer\Attributes\TaggedAs;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
@@ -33,6 +35,8 @@ use Tests\AttributeReader\AttributeOnParameter\Fixtures\FooFactory;
 #[CoversClass(InjectByCallable::class)]
 #[CoversClass(ProxyClosure::class)]
 #[CoversClass(TaggedAs::class)]
+#[CoversClass(Parameter::class)]
+#[CoversClass(ParameterRuntime::class)]
 class AttributeOnParameterTest extends TestCase
 {
     #[DataProvider('dataProviderParam')]
@@ -64,6 +68,14 @@ class AttributeOnParameterTest extends TestCase
         yield 'Inject and DiFactory' => [
             (new ReflectionFunction(static fn (#[Inject('service.one'), DiFactory(FooFactory::class)] $param) => true))->getParameters()[0],
         ];
+
+        yield 'Inject and Parameter' => [
+            (new ReflectionFunction(static fn (#[Inject('service.one'), Parameter('foo')] $param) => true))->getParameters()[0],
+        ];
+
+        yield 'DiFactory and ParameterRuntime' => [
+            (new ReflectionFunction(static fn (#[DiFactory(FooFactory::class), ParameterRuntime('foo')] $param) => true))->getParameters()[0],
+        ];
     }
 
     public function testMixedAttributes(): void
@@ -88,13 +100,15 @@ class AttributeOnParameterTest extends TestCase
             #[InjectByCallable('\uniqid')]
             #[ProxyClosure('service.heavy')]
             #[TaggedAs('tags.one')]
+            #[Parameter('foo')]
+            #[ParameterRuntime('bar')]
             mixed ...$a
         ) => '';
         $param = new ReflectionParameter($f, 0);
 
         $res = [...AttributeReader::getAttributeOnParameter($param, $this->createMock(DiContainerInterface::class))];
 
-        self::assertCount(5, $res);
+        self::assertCount(7, $res);
 
         self::assertEquals(FooFactory::class, $res[0]->definition);
         self::assertNull($res[0]->isSingleton);
@@ -108,5 +122,10 @@ class AttributeOnParameterTest extends TestCase
 
         self::assertEquals('tags.one', $res[4]->name);
         self::assertTrue($res[4]->isLazy);
+
+        self::assertEquals('foo', $res[5]->name);
+
+        self::assertEquals('bar', $res[6]->name);
+        self::assertEquals(null, $res[6]->message);
     }
 }

--- a/tests/AttributeReader/ParameterRuntime/ParameterRuntimeReaderTest.php
+++ b/tests/AttributeReader/ParameterRuntime/ParameterRuntimeReaderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\ParameterRuntime;
+
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
+use Kaspi\DiContainer\Helper;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionParameter;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(ParameterRuntime::class)]
+#[CoversClass(Helper::class)]
+class ParameterRuntimeReaderTest extends TestCase
+{
+    private ?ContainerInterface $container;
+
+    public function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->container);
+    }
+
+    public function testReadNoneVariadicManyAttributes(): void
+    {
+        $f = static fn (
+            #[ParameterRuntime('foo')]
+            #[ParameterRuntime('bar')]
+            string $a
+        ) => '';
+        $p = new ReflectionParameter($f, 0);
+
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/can be applied once per non-variadic Parameter #0.+[ <required> string \$a ]/');
+
+        AttributeReader::getAttributeOnParameter($p, $this->container)->valid();
+    }
+
+    public function testReadVariadicManyAttributes(): void
+    {
+        $f = static fn (
+            #[ParameterRuntime('foo')]
+            #[ParameterRuntime('bar')]
+            string ...$a
+        ) => '';
+        $p = new ReflectionParameter($f, 0);
+
+        self::assertTrue(AttributeReader::getAttributeOnParameter($p, $this->container)->valid());
+    }
+}

--- a/tests/Compiler/CompilableDefinition/ParameterRuntimeEntry/ParameterRuntimeEntryTest.php
+++ b/tests/Compiler/CompilableDefinition/ParameterRuntimeEntry/ParameterRuntimeEntryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Compiler\CompilableDefinition\ParameterRuntimeEntry;
+
+use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterRuntimeEntry;
+use Kaspi\DiContainer\Compiler\CompiledEntry;
+use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+
+/**
+ * @internal
+ */
+#[CoversClass(ParameterRuntimeEntry::class)]
+#[CoversClass(CompiledEntry::class)]
+class ParameterRuntimeEntryTest extends TestCase
+{
+    #[TestWith(['getDefinition', ''])]
+    #[TestWith(['getContext', ''])]
+    #[TestWith(['getContext', null])]
+    public function testEmptyParameterName(string $methodDefinition, mixed $methodWillReturn): void
+    {
+        $this->expectException(DefinitionCompileExceptionInterface::class);
+        $this->expectExceptionMessage('Parameter name must be non-empty string.');
+
+        $parameter = $this->createMock(DiDefinitionParameterRuntimeInterface::class);
+        $parameter->method($methodDefinition)->willReturn($methodWillReturn);
+
+        $entry = new ParameterRuntimeEntry($parameter);
+        self::assertEquals($methodWillReturn, $entry->getDiDefinition()->{$methodDefinition}());
+        $entry->compile('$this');
+    }
+
+    #[TestWith(['getDefinition', 'foo'])]
+    #[TestWith(['getContext', 'foo'])]
+    public function testUniqueName(string $methodDefinition, string $methodWillReturn): void
+    {
+        $parameter = $this->createMock(DiDefinitionParameterRuntimeInterface::class);
+        $parameter->method($methodDefinition)->willReturn($methodWillReturn);
+
+        $entry = new ParameterRuntimeEntry($parameter);
+        $ce = $entry->compile('$this', ['$parameters']);
+
+        self::assertEquals('$parameters1', $ce->getScopeServiceVar());
+        self::assertEquals('$parameters1->get(\''.$methodWillReturn.'\')', $ce->getExpression());
+
+        $statements = implode(';'.PHP_EOL, $ce->getStatements());
+        self::assertStringContainsString('if (!$parameters1->has(\''.$methodWillReturn.'\')) throw new', $statements);
+    }
+}

--- a/tests/Compiler/CompilableDefinition/ParameterRuntimeEntry/ParameterRuntimeEntryTest.php
+++ b/tests/Compiler/CompilableDefinition/ParameterRuntimeEntry/ParameterRuntimeEntryTest.php
@@ -6,8 +6,12 @@ namespace Tests\Compiler\CompilableDefinition\ParameterRuntimeEntry;
 
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterRuntimeEntry;
 use Kaspi\DiContainer\Compiler\CompiledEntry;
+use Kaspi\DiContainer\Exception\DefinitionCompileException;
+use Kaspi\DiContainer\Interfaces\Compiler\DiContainerDefinitionsInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
+use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -31,8 +35,9 @@ class ParameterRuntimeEntryTest extends TestCase
 
         $parameter = $this->createMock(DiDefinitionParameterRuntimeInterface::class);
         $parameter->method($methodDefinition)->willReturn($methodWillReturn);
+        $diContainerDefinitions = $this->createMock(DiContainerDefinitionsInterface::class);
 
-        $entry = new ParameterRuntimeEntry($parameter);
+        $entry = new ParameterRuntimeEntry($parameter, $diContainerDefinitions);
         self::assertEquals($methodWillReturn, $entry->getDiDefinition()->{$methodDefinition}());
         $entry->compile('$this');
     }
@@ -43,8 +48,9 @@ class ParameterRuntimeEntryTest extends TestCase
     {
         $parameter = $this->createMock(DiDefinitionParameterRuntimeInterface::class);
         $parameter->method($methodDefinition)->willReturn($methodWillReturn);
+        $diContainerDefinitions = $this->createMock(DiContainerDefinitionsInterface::class);
 
-        $entry = new ParameterRuntimeEntry($parameter);
+        $entry = new ParameterRuntimeEntry($parameter, $diContainerDefinitions);
         $ce = $entry->compile('$this', ['$parameters']);
 
         self::assertEquals('$parameters1', $ce->getScopeServiceVar());
@@ -52,5 +58,33 @@ class ParameterRuntimeEntryTest extends TestCase
 
         $statements = implode(';'.PHP_EOL, $ce->getStatements());
         self::assertStringContainsString('if (!$parameters1->has(\''.$methodWillReturn.'\')) throw new', $statements);
+    }
+
+    public function testParameterRuntimeMustBeSetInRuntimeContainer(): void
+    {
+        $this->expectException(DefinitionCompileException::class);
+        $this->expectExceptionMessage('The container\'s runtime parameter "foo" must be set in the container at runtime.');
+
+        $sourceParameters = $this->createMock(SourceParametersMutableInterface::class);
+        $sourceParameters->method('has')
+            ->with('foo')
+            ->willReturn(true)
+        ;
+
+        $container = $this->createMock(DiContainerInterface::class);
+        $container->method('parameters')
+            ->willReturn($sourceParameters)
+        ;
+
+        $diContainerDefinitions = $this->createMock(DiContainerDefinitionsInterface::class);
+        $diContainerDefinitions->method('getContainer')
+            ->willReturn($container)
+        ;
+
+        $parameter = $this->createMock(DiDefinitionParameterRuntimeInterface::class);
+        $parameter->method('getDefinition')->willReturn('foo');
+
+        $entry = new ParameterRuntimeEntry($parameter, $diContainerDefinitions);
+        $entry->compile('$this');
     }
 }

--- a/tests/Compiler/DiDefinitionTransformer/DiDefinitionTransformerTest.php
+++ b/tests/Compiler/DiDefinitionTransformer/DiDefinitionTransformerTest.php
@@ -10,6 +10,7 @@ use Kaspi\DiContainer\Compiler\CompilableDefinition\FactoryEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ObjectEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterEntry;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\ParameterRuntimeEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ProxyClosureEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\TaggedAsEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ValueEntry;
@@ -21,6 +22,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionCallableInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionFactoryInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionLinkInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionProxyClosureInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionValueInterface;
@@ -42,6 +44,7 @@ use stdClass;
 #[CoversClass(FactoryEntry::class)]
 #[CoversClass(DiDefinitionTransformer::class)]
 #[CoversClass(ParameterEntry::class)]
+#[CoversClass(ParameterRuntimeEntry::class)]
 class DiDefinitionTransformerTest extends TestCase
 {
     private object $closureParser;
@@ -108,6 +111,11 @@ class DiDefinitionTransformerTest extends TestCase
         yield 'DiDefinitionParameter' => [
             DiDefinitionParameterInterface::class,
             ParameterEntry::class,
+        ];
+
+        yield 'DiDefinitionParameterRuntime' => [
+            DiDefinitionParameterRuntimeInterface::class,
+            ParameterRuntimeEntry::class,
         ];
     }
 

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
@@ -22,6 +22,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Helper;
@@ -75,6 +76,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversClass(ParameterRuntime::class)]
 #[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPhpAttributeTest extends TestCase
 {

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpAttributeTest.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\Attributes\DiFactory;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
 use Kaspi\DiContainer\Attributes\Parameter;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
 use Kaspi\DiContainer\Attributes\ProxyClosure;
 use Kaspi\DiContainer\Attributes\TaggedAs;
 use Kaspi\DiContainer\DiContainerConfig;
@@ -20,10 +21,12 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ArgumentBuilderExceptionInterface;
 use Kaspi\DiContainer\Traits\BindArgumentsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -42,6 +45,7 @@ use Tests\DiDefinition\BuildArguments\Fixtures\QuuxTwo;
 
 use function Kaspi\DiContainer\diCallable;
 use function Kaspi\DiContainer\diGet;
+use function Kaspi\DiContainer\diParameterRuntime;
 use function Kaspi\DiContainer\diProxyClosure;
 use function Kaspi\DiContainer\diTaggedAs;
 
@@ -69,6 +73,9 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(DiDefinitionFactory::class)]
 #[CoversClass(Parameter::class)]
 #[CoversClass(DiDefinitionParameter::class)]
+#[CoversClass(ParameterRuntime::class)]
+#[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPhpAttributeTest extends TestCase
 {
     use BindArgumentsTrait;
@@ -451,5 +458,39 @@ class BuildArgumentsByPhpAttributeTest extends TestCase
 
         $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
         $ba->build();
+    }
+
+    public function testAttributeParameterRuntime(): void
+    {
+        $fn = static fn (
+            #[ParameterRuntime('foo')]
+            string $str,
+            #[ParameterRuntime]
+            string $bar,
+            #[ParameterRuntime('tmp')]
+            #[ParameterRuntime]
+            string ...$baz
+        ) => null;
+
+        $this->bindArguments(str: diParameterRuntime('qux'));
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
+        $arg = $ba->build();
+
+        self::assertCount(4, $arg);
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[0]);
+        self::assertEquals('foo', $arg[0]->getDefinition());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[1]);
+        self::assertEquals('', $arg[1]->getDefinition());
+        self::assertEquals('bar', $arg[1]->getContext());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[2]);
+        self::assertEquals('tmp', $arg[2]->getDefinition());
+        self::assertEquals('', $arg[2]->getContext());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[3]);
+        self::assertEquals('', $arg[3]->getDefinition());
+        self::assertEquals('baz', $arg[3]->getContext());
     }
 }

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpDefinitionTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpDefinitionTest.php
@@ -15,6 +15,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
@@ -64,6 +65,7 @@ use function Kaspi\DiContainer\diValue;
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
 #[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPhpDefinitionTest extends TestCase
 {

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpDefinitionTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPhpDefinitionTest.php
@@ -7,15 +7,18 @@ namespace Tests\DiDefinition\BuildArguments;
 use ArrayIterator;
 use DiDefinition\BuildArguments\Fixtures\BazInterface;
 use Kaspi\DiContainer\Attributes\Inject;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
 use Kaspi\DiContainer\DiContainerConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ArgumentBuilderExceptionInterface;
 use Kaspi\DiContainer\Reflection\ReflectionMethodByDefinition;
 use Kaspi\DiContainer\Traits\BindArgumentsTrait;
@@ -39,6 +42,7 @@ use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diFactory;
 use function Kaspi\DiContainer\diGet;
 use function Kaspi\DiContainer\diParameter;
+use function Kaspi\DiContainer\diParameterRuntime;
 use function Kaspi\DiContainer\diValue;
 
 /**
@@ -59,6 +63,8 @@ use function Kaspi\DiContainer\diValue;
 #[CoversClass(DiDefinitionFactory::class)]
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
+#[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPhpDefinitionTest extends TestCase
 {
     use BindArgumentsTrait;
@@ -496,5 +502,43 @@ class BuildArgumentsByPhpDefinitionTest extends TestCase
 
         self::assertInstanceOf(DiDefinitionParameter::class, $args[3]);
         self::assertEquals('params.bar_two', $args[3]->getDefinition());
+    }
+
+    public function testAttributeParameterRuntime(): void
+    {
+        $fn = static fn (
+            #[ParameterRuntime('qux')] // skip attribute
+            string $str,
+            string $bar,
+            #[ParameterRuntime('tmp')]
+            #[ParameterRuntime]
+            string ...$baz
+        ) => null;
+
+        $this->bindArguments(
+            diParameterRuntime('foo'),
+            diParameterRuntime(),
+            diParameterRuntime('tmp'),
+            diParameterRuntime(),
+        );
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
+        $arg = $ba->build();
+
+        self::assertCount(4, $arg);
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[0]);
+        self::assertEquals('foo', $arg[0]->getDefinition());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[1]);
+        self::assertEquals('', $arg[1]->getDefinition());
+        self::assertEquals('bar', $arg[1]->getContext());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[2]);
+        self::assertEquals('tmp', $arg[2]->getDefinition());
+        self::assertEquals('', $arg[2]->getContext());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $arg[3]);
+        self::assertEquals('', $arg[3]->getDefinition());
+        self::assertEquals('baz', $arg[3]->getContext());
     }
 }

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
@@ -13,6 +13,7 @@ use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
@@ -48,6 +49,7 @@ use function Kaspi\DiContainer\diParameterRuntime;
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversClass(DiDefinitionParameterRuntime::class)]
 #[CoversClass(ParameterRuntime::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
 #[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPriorityBindArgumentsTest extends TestCase

--- a/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
+++ b/tests/DiDefinition/BuildArguments/BuildArgumentsByPriorityBindArgumentsTest.php
@@ -7,12 +7,15 @@ namespace Tests\DiDefinition\BuildArguments;
 use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\Parameter;
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
 use Kaspi\DiContainer\DiContainerConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionParameterRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ArgumentBuilderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Traits\BindArgumentsTrait;
@@ -29,6 +32,7 @@ use Tests\DiDefinition\BuildArguments\Fixtures\QuuxInterface;
 
 use function Kaspi\DiContainer\diGet;
 use function Kaspi\DiContainer\diParameter;
+use function Kaspi\DiContainer\diParameterRuntime;
 
 /**
  * @internal
@@ -42,7 +46,10 @@ use function Kaspi\DiContainer\diParameter;
 #[CoversClass(Helper::class)]
 #[CoversClass(BindArgumentsTrait::class)]
 #[CoversClass(DiDefinitionParameter::class)]
+#[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversClass(ParameterRuntime::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
+#[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class BuildArgumentsByPriorityBindArgumentsTest extends TestCase
 {
     use BindArgumentsTrait;
@@ -124,5 +131,30 @@ class BuildArgumentsByPriorityBindArgumentsTest extends TestCase
             ],
             $args
         );
+    }
+
+    public function testAttributeParameterRuntime(): void
+    {
+        $fn = static fn (
+            #[Parameter('foo')]
+            string $str,
+            #[ParameterRuntime]
+            string $bar,
+        ) => null;
+
+        $this->bindArguments(str: diParameterRuntime('qux'));
+
+        $ba = new ArgumentBuilder($this->getBindArguments(), new ReflectionFunction($fn), $this->mockContainer);
+
+        // 🚩 Use Php attribute and bind arguments - bind arguments highest priority.
+        $args = $ba->buildByPriorityBindArguments();
+
+        self::assertCount(2, $args);
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $args[0]);
+        self::assertEquals('qux', $args[0]->getDefinition());
+
+        self::assertInstanceOf(DiDefinitionParameterRuntimeInterface::class, $args[1]);
+        self::assertEquals('', $args[1]->getDefinition());
+        self::assertEquals('bar', $args[1]->getContext());
     }
 }

--- a/tests/DiDefinition/DiDefinitionParameter/DiDefinitionParameterTest.php
+++ b/tests/DiDefinition/DiDefinitionParameter/DiDefinitionParameterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\DiDefinition\DiDefinitionParameter;
 
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Exception\ParameterException;
 use Kaspi\DiContainer\Exception\ParameterNotFoundException;
@@ -24,6 +25,7 @@ use ReflectionParameter;
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversClass(NotFoundException::class)]
 #[CoversClass(ParameterNotFoundException::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 class DiDefinitionParameterTest extends TestCase
 {
     #[TestWith(['name' => '', 'expect' => ''])]

--- a/tests/DiDefinition/DiDefinitionParameter/ResolveParameterTest.php
+++ b/tests/DiDefinition/DiDefinitionParameter/ResolveParameterTest.php
@@ -10,6 +10,7 @@ use Kaspi\DiContainer\Attributes\Parameter;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Exception\ParameterNotFoundException;
 use Kaspi\DiContainer\Helper;
@@ -37,6 +38,7 @@ use function Kaspi\DiContainer\diParameter;
 #[CoversClass(Helper::class)]
 #[CoversClass(NotFoundException::class)]
 #[CoversClass(ParameterNotFoundException::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 class ResolveParameterTest extends TestCase
 {
     private DiContainerInterface $container;

--- a/tests/DiDefinition/DiDefinitionParameterRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionParameterRuntime/DiDefinitionRuntimeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\DiDefinition\DiDefinitionParameterRuntime;
 
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterWithContextAbstract;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  * @internal
  */
 #[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversClass(DiDefinitionParameterWithContextAbstract::class)]
 class DiDefinitionRuntimeTest extends TestCase
 {
     private SourceParametersMutableInterface $sourceParams;

--- a/tests/DiDefinition/DiDefinitionParameterRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionParameterRuntime/DiDefinitionRuntimeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionParameterRuntime;
+
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(DiDefinitionParameterRuntime::class)]
+class DiDefinitionRuntimeTest extends TestCase
+{
+    private SourceParametersMutableInterface $sourceParams;
+    private DiContainerInterface $container;
+
+    protected function setUp(): void
+    {
+        $this->sourceParams = $this->createMock(SourceParametersMutableInterface::class);
+        $this->container = $this->createMock(DiContainerInterface::class);
+        $this->container->method('parameters')->willReturn($this->sourceParams);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->sourceParams, $this->container);
+    }
+
+    public function testParameterNameNotDefined(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('Parameter name must be non-empty string');
+
+        $this->sourceParams->expects(self::never())
+            ->method('has')
+        ;
+
+        $p = new DiDefinitionParameterRuntime();
+        $p->resolve($this->container);
+    }
+
+    public function testResolveWithName(): void
+    {
+        $paramName = 'foo';
+
+        $this->sourceParams->expects(self::once())
+            ->method('has')
+            ->with($paramName)
+            ->willReturn(true)
+        ;
+        $this->sourceParams->expects(self::once())
+            ->method('get')
+            ->with($paramName)
+            ->willReturn('bar')
+        ;
+
+        $p = new DiDefinitionParameterRuntime($paramName);
+
+        self::assertEquals('bar', $p->resolve($this->container));
+        self::assertEquals($paramName, $p->getDefinition());
+        self::assertNull($p->getContext());
+    }
+
+    public function testResolveWithSetContext(): void
+    {
+        $paramName = 'foo';
+
+        $this->sourceParams->expects(self::once())
+            ->method('has')
+            ->with($paramName)
+            ->willReturn(true)
+        ;
+        $this->sourceParams->expects(self::once())
+            ->method('get')
+            ->with($paramName)
+            ->willReturn('bar')
+        ;
+
+        $p = (new DiDefinitionParameterRuntime())
+            ->setContext($paramName)
+        ;
+
+        self::assertEquals('bar', $p->resolve($this->container));
+        self::assertEquals($paramName, $p->getContext());
+        self::assertEquals('', $p->getDefinition());
+    }
+
+    public function testResolveWithContext(): void
+    {
+        $paramName = 'foo';
+
+        $this->sourceParams->expects(self::once())
+            ->method('has')
+            ->with($paramName)
+            ->willReturn(true)
+        ;
+        $this->sourceParams->expects(self::once())
+            ->method('get')
+            ->with($paramName)
+            ->willReturn('bar')
+        ;
+
+        $p = new DiDefinitionParameterRuntime();
+
+        self::assertEquals('bar', $p->resolve($this->container, $paramName));
+        self::assertNull($p->getContext());
+        self::assertEquals('', $p->getDefinition());
+    }
+
+    public function testResolveWhenParameterNotDefined(): void
+    {
+        $paramName = 'foo';
+        $message = 'You are forget to define parameter "foo"';
+
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage($message);
+
+        $this->sourceParams->expects(self::never())
+            ->method('get')
+        ;
+
+        $this->sourceParams->expects(self::once())
+            ->method('has')
+            ->with($paramName)
+            ->willReturn(false)
+        ;
+
+        $p = new DiDefinitionParameterRuntime($paramName, $message);
+
+        self::assertEquals($message, $p->getMessage());
+
+        $p->resolve($this->container);
+    }
+}

--- a/tests/Function/HelperFunctionTest.php
+++ b/tests/Function/HelperFunctionTest.php
@@ -146,6 +146,6 @@ class HelperFunctionTest extends TestCase
         $p = diParameterRuntime($name, $message);
 
         self::assertEquals($expectDefinition, $p->getDefinition());
-        self::assertEquals($expectMessage, $p->getMessage());
+        self::assertStringContainsString($expectMessage, $p->getMessage());
     }
 }

--- a/tests/Function/HelperFunctionTest.php
+++ b/tests/Function/HelperFunctionTest.php
@@ -9,6 +9,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
@@ -27,6 +28,7 @@ use function Kaspi\DiContainer\diAutowire;
 use function Kaspi\DiContainer\diCallable;
 use function Kaspi\DiContainer\diGet;
 use function Kaspi\DiContainer\diParameter;
+use function Kaspi\DiContainer\diParameterRuntime;
 use function Kaspi\DiContainer\diProxyClosure;
 use function Kaspi\DiContainer\diTaggedAs;
 
@@ -47,6 +49,8 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(Helper::class)]
 #[CoversClass(DiDefinitionParameter::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
+#[CoversClass(DiDefinitionParameterRuntime::class)]
+#[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
 class HelperFunctionTest extends TestCase
 {
     public function testFunctiondiGet(): void
@@ -133,5 +137,15 @@ class HelperFunctionTest extends TestCase
     public function testDiParam(string $name, string $expectDefinition): void
     {
         self::assertEquals($expectDefinition, diParameter($name)->getDefinition());
+    }
+
+    #[TestWith(['foo', 'foo', 'msg', 'msg'])]
+    #[TestWith(['', '', null, 'Did you forget to define it?'])]
+    public function testDiParameterRuntime(string $name, string $expectDefinition, ?string $message, ?string $expectMessage): void
+    {
+        $p = diParameterRuntime($name, $message);
+
+        self::assertEquals($expectDefinition, $p->getDefinition());
+        self::assertEquals($expectMessage, $p->getMessage());
     }
 }

--- a/tests/Integration/ContainerParameter/ContainerParameterOnCompiledContainerTest.php
+++ b/tests/Integration/ContainerParameter/ContainerParameterOnCompiledContainerTest.php
@@ -26,7 +26,7 @@ use function substr;
  * @internal
  */
 #[CoversNothing]
-class ContainerParameterCompiledTest extends TestCase
+class ContainerParameterOnCompiledContainerTest extends TestCase
 {
     public function testCompileParameterInConstructor(): void
     {

--- a/tests/Integration/ContainerParameter/ContainerParameterOnRuntimeContainerTest.php
+++ b/tests/Integration/ContainerParameter/ContainerParameterOnRuntimeContainerTest.php
@@ -16,7 +16,7 @@ use Tests\Integration\ContainerParameter\Fixtures\FooAttr;
  * @internal
  */
 #[CoversNothing]
-class ContainerParameterRuntimeTest extends TestCase
+class ContainerParameterOnRuntimeContainerTest extends TestCase
 {
     public function testResolveParameterInConstructor(): void
     {

--- a/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnCompiledContainerTest.php
+++ b/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnCompiledContainerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ContainerParameterRuntime;
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\ContainerParameterRuntime\Fixtures\Bar;
+use Tests\Integration\ContainerParameterRuntime\Fixtures\Foo;
+
+use function bin2hex;
+use function Kaspi\DiContainer\diAutowire;
+use function Kaspi\DiContainer\diParameterRuntime;
+use function random_bytes;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+class ContainerParameterRuntimeOnCompiledContainerTest extends TestCase
+{
+    protected DiContainerInterface $container;
+
+    protected function setUp(): void
+    {
+        $containerClass = 'Container_'.bin2hex(random_bytes(16));
+
+        vfsStream::setup('root');
+
+        $this->container = (new DiContainerBuilder(
+            new DiContainerConfig(
+                useZeroConfigurationDefinition: false
+            )
+        ))
+            ->addDefinitions([
+                diAutowire(Foo::class)
+                    ->bindArguments(
+                        diParameterRuntime(),
+                        baz: diParameterRuntime('qux.value')
+                    ),
+                // Use php attribute for configure parameters
+                diAutowire(Bar::class),
+            ])
+            ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
+            ->build()
+        ;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->container);
+    }
+
+    public function testCompileDiDefinitionParameterRuntime(): void
+    {
+        $this->container->parameters()->add(['bar' => 'ola', 'qux.value' => 1_000]);
+
+        self::assertEquals(['bar' => 'ola', 'baz' => 1_000], (array) $this->container->get(Foo::class));
+
+        $this->container->parameters()->set('bat', 'aloha');
+
+        self::assertEquals(['bat' => 'aloha', 'qux' => 1_000], (array) $this->container->get(Bar::class));
+    }
+
+    public function testParameterRuntimeNotDefined(): void
+    {
+        $this->expectException(ParameterNotFoundExceptionInterface::class);
+        $this->expectExceptionMessage('The container parameter "qux.value" must be set in the container at runtime');
+
+        $this->container->parameters()->set('bat', 'aloha');
+        $this->container->get(Bar::class);
+    }
+}

--- a/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnCompiledContainerTest.php
+++ b/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnCompiledContainerTest.php
@@ -6,7 +6,8 @@ namespace Tests\Integration\ContainerParameterRuntime;
 
 use Kaspi\DiContainer\DiContainerBuilder;
 use Kaspi\DiContainer\DiContainerConfig;
-use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiContainerBuilderInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerBuilderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ParameterNotFoundExceptionInterface;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -25,7 +26,7 @@ use function random_bytes;
 #[CoversNothing]
 class ContainerParameterRuntimeOnCompiledContainerTest extends TestCase
 {
-    protected DiContainerInterface $container;
+    protected DiContainerBuilderInterface $containerBuilder;
 
     protected function setUp(): void
     {
@@ -33,39 +34,39 @@ class ContainerParameterRuntimeOnCompiledContainerTest extends TestCase
 
         vfsStream::setup('root');
 
-        $this->container = (new DiContainerBuilder(
+        $this->containerBuilder = (new DiContainerBuilder(
             new DiContainerConfig(
                 useZeroConfigurationDefinition: false
             )
         ))
             ->addDefinitions([
+                // Use php attribute for configure parameters
+                diAutowire(Bar::class),
                 diAutowire(Foo::class)
                     ->bindArguments(
                         diParameterRuntime(),
                         baz: diParameterRuntime('qux.value')
                     ),
-                // Use php attribute for configure parameters
-                diAutowire(Bar::class),
             ])
             ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
-            ->build()
         ;
     }
 
     protected function tearDown(): void
     {
-        unset($this->container);
+        unset($this->containerBuilder);
     }
 
     public function testCompileDiDefinitionParameterRuntime(): void
     {
-        $this->container->parameters()->add(['bar' => 'ola', 'qux.value' => 1_000]);
+        $container = $this->containerBuilder->build();
+        $container->parameters()->add(['bar' => 'ola', 'qux.value' => 1_000]);
 
-        self::assertEquals(['bar' => 'ola', 'baz' => 1_000], (array) $this->container->get(Foo::class));
+        self::assertEquals(['bar' => 'ola', 'baz' => 1_000], (array) $container->get(Foo::class));
 
-        $this->container->parameters()->set('bat', 'aloha');
+        $container->parameters()->set('bat', 'aloha');
 
-        self::assertEquals(['bat' => 'aloha', 'qux' => 1_000], (array) $this->container->get(Bar::class));
+        self::assertEquals(['bat' => 'aloha', 'qux' => 1_000], (array) $container->get(Bar::class));
     }
 
     public function testParameterRuntimeNotDefined(): void
@@ -73,7 +74,23 @@ class ContainerParameterRuntimeOnCompiledContainerTest extends TestCase
         $this->expectException(ParameterNotFoundExceptionInterface::class);
         $this->expectExceptionMessage('The container parameter "qux.value" must be set in the container at runtime');
 
-        $this->container->parameters()->set('bat', 'aloha');
-        $this->container->get(Bar::class);
+        $container = $this->containerBuilder->build();
+        $container->parameters()->set('bat', 'aloha');
+        $container->get(Bar::class);
+    }
+
+    public function testCannotCompileParameterRuntimeWhenParameterAlreadyRegistered(): void
+    {
+        $this->expectException(ContainerBuilderExceptionInterface::class);
+        $this->expectExceptionMessage('Tests\Integration\ContainerParameterRuntime\Fixtures\Bar::__construct()');
+
+        /*
+         * The parameter 'qux.value' defined before compile,
+         * this definition fire exception because parameter Bar::$qux
+         * has php attribute #[ParameterRuntime('qux.value')].
+         * The parameter runtime must be defined in runtime container.
+        */
+        $this->containerBuilder->addParameters(['qux.value' => 1_000]);
+        $this->containerBuilder->build();
     }
 }

--- a/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnRuntimeContainerTest.php
+++ b/tests/Integration/ContainerParameterRuntime/ContainerParameterRuntimeOnRuntimeContainerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ContainerParameterRuntime;
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\ContainerParameterRuntime\Fixtures\Bar;
+use Tests\Integration\ContainerParameterRuntime\Fixtures\Foo;
+
+use function Kaspi\DiContainer\diAutowire;
+use function Kaspi\DiContainer\diParameterRuntime;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+class ContainerParameterRuntimeOnRuntimeContainerTest extends TestCase
+{
+    protected DiContainerInterface $container;
+
+    protected function setUp(): void
+    {
+        $this->container = (new DiContainerBuilder(
+            new DiContainerConfig(
+                useZeroConfigurationDefinition: false
+            )
+        ))
+            ->addDefinitions([
+                diAutowire(Foo::class)
+                    ->bindArguments(
+                        diParameterRuntime(),
+                        baz: diParameterRuntime('qux.value')
+                    ),
+                // Use php attribute for configure parameters
+                diAutowire(Bar::class),
+            ])
+            ->build()
+        ;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->container);
+    }
+
+    public function testCompileDiDefinitionParameterRuntime(): void
+    {
+        $this->container->parameters()->add(['bar' => 'ola', 'qux.value' => 1_000]);
+
+        self::assertEquals(['bar' => 'ola', 'baz' => 1_000], (array) $this->container->get(Foo::class));
+
+        $this->container->parameters()->set('bat', 'aloha');
+
+        self::assertEquals(['bat' => 'aloha', 'qux' => 1_000], (array) $this->container->get(Bar::class));
+    }
+
+    public function testParameterRuntimeNotDefined(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('Cannot resolve parameter at position #1');
+
+        $this->container->parameters()->set('bat', 'aloha');
+        $this->container->get(Bar::class);
+    }
+}

--- a/tests/Integration/ContainerParameterRuntime/Fixtures/Bar.php
+++ b/tests/Integration/ContainerParameterRuntime/Fixtures/Bar.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ContainerParameterRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\ParameterRuntime;
+
+class Bar
+{
+    public function __construct(
+        #[ParameterRuntime]
+        public string $bat,
+        #[ParameterRuntime('qux.value')]
+        public int $qux
+    ) {}
+}

--- a/tests/Integration/ContainerParameterRuntime/Fixtures/Foo.php
+++ b/tests/Integration/ContainerParameterRuntime/Fixtures/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ContainerParameterRuntime\Fixtures;
+
+class Foo
+{
+    public function __construct(public string $bar, public int $baz) {}
+}


### PR DESCRIPTION
Resolve #515 

- [x] Реализация интерфейса `DiDefinitionParameterRuntimeInterface`
- [x] Новая хелпер функция `diParameterRuntime`
- [x] Новый PHP атрибуит `ParameterRuntime`
- [x] Обновить `\Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder` для `DiDefinitionParameterRuntimeInterface`
- [x] Компиляция определения
- [x] Добавить тесты (Runtime, скомпилированный контейнер)
- [x] Обновить документацию по параметрам контейнера