### PR TITLE
Runtime DI definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ var_dump($container->get(TestClass::class)->container instanceof ContainerInterf
 * 📦 [Метод контейнера `call()`](https://github.com/agdobrynin/di-container/blob/main/docs/03-call-method.md) для вызова чистых `callable` типов и дополнительных определений.
 * 🔖 [Тэгирование определений и сервисов](https://github.com/agdobrynin/di-container/blob/main/docs/05-tags.md).
 * 📋 [Параметры контейнера](https://github.com/agdobrynin/di-container/blob/main/docs/09-container-parameters.md).
+* 🗳️ [Внедрение экземпляра класса в рантайм контейнер](https://github.com/agdobrynin/di-container/blob/main/docs/10-runtime-definition.md).
 
 ## Тесты
 Прогнать тесты без подсчёта покрытия кода

--- a/docs/06-container-builder.md
+++ b/docs/06-container-builder.md
@@ -156,6 +156,7 @@ return static function (DefinitionsConfiguratorInterface $configurator): void {
 > [!TIP]
 > Для некоторых определений идентификатор контейнера может быть сформирован автоматически.
 > - [хэлпер функция `diAutowire()`](01-php-definition.md#diautowire)
+> - [хэлпер функция `diRuntime()`](10-runtime-definition.md#diruntime)
 > - [PHP атрибут `#[Autowire()]`](02-attribute-definition.md#autowire)
 >
 

--- a/docs/10-runtime-definition.md
+++ b/docs/10-runtime-definition.md
@@ -1,0 +1,90 @@
+# 🗳️ Внедрение экземпляра класса в рантайм контейнер.
+В некоторых сценариях использования контейнера может возникнуть ситуация когда на момент конфигурации
+и сборки контейнера экземпляр класса используемый в определении заранее неизвестен
+и может быть установлен только во время выполнения контейнера,
+но другие определения контейнера могут зависеть от такого сервиса (_класса_).
+
+Определения устанавливаемые во время выполнения контейнера, называются «Runtime definition».
+В файлах конфигураций используется «Runtime definition» чтобы контейнер знал о существовании такого определения
+во время [компиляции контейнера](06-container-builder.md#компиляция-контейнера)
+(_в противном случае другие определения контейнера, зависящие от «runtime definition», получат ошибку так как не найдут его в конфигурации_).
+
+## diRuntime
+Хелпер функция для конфигурации «Runtime definition» в списке зарегистрированных определений.
+
+```php
+use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use function \Kaspi\DiContainer\diRuntime;
+
+diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoArgumentsInterface
+```
+Параметры:
+- `$containerIdentifier` – идентификатора контейнера (php класс, интерфейс или непустая строка) реализующий сервис, который будет добавлен позже.
+- `$message` – дополнительное информационное сообщение при ошибке.
+
+> [!WARNING]
+> Хелпер функция не может быть применена к параметрам метода класса или callable выражения.
+> 
+
+> [!NOTE]
+> `$containerIdentifier` может быть представлен любой не пустой строкой
+> чтобы сервис можно было получить через метод контейнера `get()`.
+> 
+> Хелпер функция `diRuntime()` не создает конфигурацию экземпляра класса, а только предоставляет идентификатор контейнера.
+>
+
+## Пример использования.
+Конфигурация специализированных определений:
+```php
+// /app/config/runtime_definitions.php
+use App\Core\Kernel;
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use function Kaspi\DiContainer\diRuntime;
+
+return static function (DefinitionsConfiguratorInterface $configurator) {
+    yield diRuntime(Kernel::class);
+
+    yield diRuntime('secure_string');
+};
+```
+> [!NOTE]
+> Другие определения в конфигурации могут «ссылаться»
+> на идентификаторы контейнера `'App\\Core\\Kernel'` и `'secure_string'`
+> - через [хелпер функцию `diGet()`](01-php-definition.md#diget):
+>   - `diGet(\App\Core\Kernel::class)`
+>   - `diGet('secure_string')`
+> - через [php атрибут `Inject`](02-attribute-definition.md#inject):
+>   - `#[Inject(\App\Core\Kernel::class)]`
+>   - `#[Inject('secure_string')]`
+> 
+
+Конфигурация контейнера:
+```php
+use Kaspi\DiContainer\DiContainerBuilder;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', '/app/src/')
+    ->load('/app/config/runtime_definitions.php')
+    ->build()
+;
+```
+Установка созданных экземпляров классов в «runtime definition»:
+```php
+namespace Core;
+
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+
+class Kernel {
+    public function __construct(private DiContainerInterface $container) {}
+    // ...
+    protected function initKernel(): void
+    {
+        // ...
+
+        $this->container->set($this::class, $this);
+        
+        $secureString = \calculate_secure_string();
+        $this->container->set('secure_string', $secureString);
+    }
+}
+```

--- a/src/DiContainer/Compiler/ContainerCompiler.php
+++ b/src/DiContainer/Compiler/ContainerCompiler.php
@@ -21,6 +21,7 @@ use Kaspi\DiContainer\Interfaces\Compiler\DiContainerDefinitionsInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\DiDefinitionTransformerInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Throwable;
@@ -40,6 +41,13 @@ use function var_export;
 final class ContainerCompiler implements ContainerCompilerInterface
 {
     private CompiledContainerFQNInterface $compiledContainerFQN;
+
+    /**
+     * The property used in the file `template.php`.
+     *
+     * @var array<non-empty-string, DiDefinitionRuntimeInterface>
+     */
+    private array $runtimeDefinitions = []; // @phpstan-ignore property.onlyWritten
 
     /**
      * @param class-string $containerClass container class as fully qualified name
@@ -105,6 +113,7 @@ final class ContainerCompiler implements ContainerCompilerInterface
     public function compile(): string
     {
         $definitions = $this->containerDefinitions();
+        $this->runtimeDefinitions = [];
 
         while ($definitions->valid()) {
             try {
@@ -140,6 +149,10 @@ final class ContainerCompiler implements ContainerCompilerInterface
                 }
 
                 $compiledEntry = $this->compiledExceptionStack($exception, $id);
+            }
+
+            if ($definition instanceof DiDefinitionRuntimeInterface) {
+                $this->runtimeDefinitions[$id] = $definition;
             }
 
             $this->compiledEntries->setServiceMethod($id, $compiledEntry);

--- a/src/DiContainer/Compiler/ContainerCompiler.php
+++ b/src/DiContainer/Compiler/ContainerCompiler.php
@@ -47,7 +47,7 @@ final class ContainerCompiler implements ContainerCompilerInterface
      *
      * @var array<non-empty-string, DiDefinitionRuntimeInterface>
      */
-    private array $runtimeDefinitions = []; // @phpstan-ignore property.onlyWritten
+    private array $runtimeDefinitions = [];
 
     /**
      * @param class-string $containerClass container class as fully qualified name
@@ -121,6 +121,18 @@ final class ContainerCompiler implements ContainerCompilerInterface
                 $definition = $definitions->current();
                 $id = $definitions->key();
 
+                /*
+                 * Runtime definition not compilable.
+                 *
+                 * These definitions provide only IDs for container method `has()`.
+                 */
+                if ($definition instanceof DiDefinitionRuntimeInterface) {
+                    $this->runtimeDefinitions[$id] = $definition;
+                    $definitions->next();
+
+                    continue;
+                }
+
                 if ($definition instanceof InvalidDefinitionCompileException
                     || $definition instanceof NotFoundExceptionInterface) {
                     throw $definition;
@@ -151,10 +163,6 @@ final class ContainerCompiler implements ContainerCompilerInterface
                 $compiledEntry = $this->compiledExceptionStack($exception, $id);
             }
 
-            if ($definition instanceof DiDefinitionRuntimeInterface) {
-                $this->runtimeDefinitions[$id] = $definition;
-            }
-
             $this->compiledEntries->setServiceMethod($id, $compiledEntry);
 
             $definitions->next();
@@ -165,6 +173,24 @@ final class ContainerCompiler implements ContainerCompilerInterface
         require __DIR__.'/template.php';
 
         return (string) ob_get_clean();
+    }
+
+    /**
+     * Get container identifies for method `has()` in compiled container.
+     *
+     * @return Generator<int, non-empty-string>
+     *
+     * @phpstan-ignore method.unused
+     */
+    private function getForHasMethod(): Generator
+    {
+        $this->compiledEntries->getHasIdentifiers()->rewind();
+
+        yield from $this->compiledEntries->getHasIdentifiers();
+
+        foreach ($this->runtimeDefinitions as $runtimeDefinition) {
+            yield $runtimeDefinition->getIdentifier();
+        }
     }
 
     /**

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -30,9 +30,19 @@ use Kaspi\DiContainer\Exception\{
 
 final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\DiContainer\DiContainer
 {
-    public function __construct()
-    {
+    public function __construct(
+        private readonly array $runtimeDefinitionIds = [
+<?php foreach ($this->runtimeDefinitions as $id => $definition) { ?>
+            <?php echo \sprintf('%s => true', \var_export($id, true)); ?>,
+<?php } ?>
+        ]
+    ) {
         parent::__construct(
+            [
+<?php foreach ($this->runtimeDefinitions as $id => $definition) { ?>
+                <?php echo \sprintf('\Kaspi\DiContainer\diRuntime(%s, %s)', \var_export($id, true), \var_export($definition->getMessage(), true)); ?>,
+<?php } ?>
+            ],
             config: new class implements \Kaspi\DiContainer\Interfaces\DiContainerConfigInterface {
                 public function isSingletonServiceDefault(): bool
                 {
@@ -53,7 +63,7 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
 if ($config->isUseZeroConfigurationDefinition()) {?>
             removedDefinitionIds: [
 <?php foreach ($this->diContainerDefinitions->getContainer()->getRemovedDefinitionIds() as $id => $v) {?>
-                <?php echo var_export($id, true); ?> => true,
+                <?php echo \var_export($id, true); ?> => true,
 <?php } ?>
             ]
 <?php } ?>
@@ -62,7 +72,7 @@ if ($config->isUseZeroConfigurationDefinition()) {?>
 
     public function set(string $id, mixed $definition): static
     {
-        if (false === $this->containerIdMapMethod($id)) {
+        if (isset($this->runtimeDefinitionIds[$id]) || false === $this->containerIdMapMethod($id)) {
             return parent::set($id, $definition);
         }
 

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -10,6 +10,7 @@ echo '<?php';
 
 /** @var DiContainerConfigInterface $config */
 $config = $this->diContainerDefinitions->getContainer()->getConfig();
+$runtimeDefinitions = $this->runtimeDefinitions;
 ?>
 
 declare(strict_types=1);
@@ -32,17 +33,19 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
 {
     public function __construct(
         private readonly array $runtimeDefinitionIds = [
-<?php foreach ($this->runtimeDefinitions as $id => $definition) { ?>
+<?php foreach ($runtimeDefinitions as $id => $definition) { ?>
             <?php echo \sprintf('%s => true', \var_export($id, true)); ?>,
 <?php } ?>
         ]
     ) {
         parent::__construct(
-            [
-<?php foreach ($this->runtimeDefinitions as $id => $definition) { ?>
-                <?php echo \sprintf('\Kaspi\DiContainer\diRuntime(%s, %s)', \var_export($id, true), \var_export($definition->getMessage(), true)); ?>,
+<?php if ([] !== $runtimeDefinitions) { ?>
+            definitions: (static function (): \Generator {
+<?php foreach ($runtimeDefinitions as $id => $definition) { ?>
+                <?php echo \sprintf('yield \Kaspi\DiContainer\diRuntime(%s, %s);'.PHP_EOL, \var_export($id, true), \var_export($definition->getMessage(), true)); ?>
 <?php } ?>
-            ],
+            })(),
+<?php } ?>
             config: new class implements \Kaspi\DiContainer\Interfaces\DiContainerConfigInterface {
                 public function isSingletonServiceDefault(): bool
                 {
@@ -59,13 +62,12 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
                     return <?php echo \var_export($config->isUseAttribute(), true); ?>;
                 }
             },
-<?php
-if ($config->isUseZeroConfigurationDefinition()) {?>
-            removedDefinitionIds: [
+<?php if ($this->diContainerDefinitions->getContainer()->getRemovedDefinitionIds()->valid()) { ?>
+            removedDefinitionIds: (static function (): \Generator {
 <?php foreach ($this->diContainerDefinitions->getContainer()->getRemovedDefinitionIds() as $id => $v) {?>
-                <?php echo \var_export($id, true); ?> => true,
+                <?php echo \sprintf('yield %s => true;'.PHP_EOL, \var_export($id, true))?>
 <?php } ?>
-            ]
+            })()
 <?php } ?>
         );
     }

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -26,18 +26,12 @@ use function array_key_exists;
 use Kaspi\DiContainer\Exception\{
     CallCircularDependencyException,
     ContainerAlreadyRegisteredException,
-    NotFoundException,
 };
 
 final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\DiContainer
 {
-    public function __construct(
-        private readonly array $runtimeDefinitionIds = [
-<?php foreach ($runtimeDefinitions as $id => $definition) { ?>
-            <?php echo \sprintf('%s => true', \var_export($id, true)); ?>,
-<?php } ?>
-        ]
-    ) {
+    public function __construct()
+    {
         parent::__construct(
 <?php if ([] !== $runtimeDefinitions) { ?>
             definitions: (static function (): \Generator {
@@ -74,7 +68,7 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
 
     public function set(string $id, mixed $definition): static
     {
-        if (isset($this->runtimeDefinitionIds[$id]) || false === $this->containerIdMapMethod($id)) {
+        if (false === $this->containerIdMapMethod($id)) {
             return parent::set($id, $definition);
         }
 
@@ -85,17 +79,11 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
 
     public function get(string $id): mixed
     {
-        if (isset($this->runtimeDefinitionIds[$id])) {
-            return parent::get($id);
-        }
-
         /** @var false|non-empty-string $method */
         $method = $this->containerIdMapMethod($id);
 
         if (false === $method) {
-            return $this->config->isUseZeroConfigurationDefinition()
-                ? parent::get($id)
-                : throw new NotFoundException(id: $id);
+            return parent::get($id);
         }
 
         try {
@@ -114,7 +102,7 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
     public function has(string $id): bool
     {
 <?php
-$expressionHasDefault = $config->isUseZeroConfigurationDefinition() ? 'parent::has($id)' : 'false';
+$expressionHasDefault = 'parent::has($id)';
 
 if (!$idsForHasMethod->valid()) {?>
         return <?php echo $expressionHasDefault; ?>;

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -1,23 +1,23 @@
 <?php
 
 declare(strict_types=1);
-use Kaspi\DiContainer\Compiler\ContainerCompiler;
-use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
 
 // Template for compiled container.
-/** @var ContainerCompiler $this */
+/** @var \Kaspi\DiContainer\Compiler\ContainerCompiler $this */
 echo '<?php';
-
-/** @var DiContainerConfigInterface $config */
+$definitions = $this->diContainerDefinitions;
 $config = $this->diContainerDefinitions->getContainer()->getConfig();
+$compiledEntries = $this->compiledEntries;
 $runtimeDefinitions = $this->runtimeDefinitions;
+$idsForHasMethod = $this->getForHasMethod();
+$containerFQN = $this->getContainerFQN();
 ?>
 
 declare(strict_types=1);
 <?php
-if ('' !== $this->getContainerFQN()->getNamespace()) { ?>
+if ('' !== $containerFQN->getNamespace()) { ?>
 
-namespace <?php echo $this->getContainerFQN()->getNamespace(); ?>;
+namespace <?php echo $containerFQN->getNamespace(); ?>;
 
 use function array_keys;
 use function array_key_exists;
@@ -29,7 +29,7 @@ use Kaspi\DiContainer\Exception\{
     NotFoundException,
 };
 
-final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\DiContainer\DiContainer
+final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\DiContainer
 {
     public function __construct(
         private readonly array $runtimeDefinitionIds = [
@@ -62,9 +62,9 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
                     return <?php echo \var_export($config->isUseAttribute(), true); ?>;
                 }
             },
-<?php if ($this->diContainerDefinitions->getContainer()->getRemovedDefinitionIds()->valid()) { ?>
+<?php if ($definitions->getContainer()->getRemovedDefinitionIds()->valid()) { ?>
             removedDefinitionIds: (static function (): \Generator {
-<?php foreach ($this->diContainerDefinitions->getContainer()->getRemovedDefinitionIds() as $id => $v) {?>
+<?php foreach ($definitions->getContainer()->getRemovedDefinitionIds() as $id => $v) {?>
                 <?php echo \sprintf('yield %s => true;'.PHP_EOL, \var_export($id, true))?>
 <?php } ?>
             })()
@@ -85,6 +85,10 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
 
     public function get(string $id): mixed
     {
+        if (isset($this->runtimeDefinitionIds[$id])) {
+            return parent::get($id);
+        }
+
         /** @var false|non-empty-string $method */
         $method = $this->containerIdMapMethod($id);
 
@@ -112,11 +116,11 @@ final class <?php echo $this->getContainerFQN()->getClass(); ?> extends \Kaspi\D
 <?php
 $expressionHasDefault = $config->isUseZeroConfigurationDefinition() ? 'parent::has($id)' : 'false';
 
-if (!$this->compiledEntries->getHasIdentifiers()->valid()) {?>
+if (!$idsForHasMethod->valid()) {?>
         return <?php echo $expressionHasDefault; ?>;
 <?php } else { ?>
         return match($id) {<?php
-    $hasIds = $this->compiledEntries->getHasIdentifiers();
+    $hasIds = $idsForHasMethod;
     do {
         $id = $hasIds->current();
         $hasIds->next();
@@ -140,14 +144,14 @@ if (!$this->compiledEntries->getHasIdentifiers()->valid()) {?>
     private function containerIdMapMethod(string $id): false|string
     {
         return match($id) {
-<?php foreach ($this->compiledEntries->getContainerIdentifierMappedMethodResolve() as ['id' => $id, 'serviceMethod' => $serviceMethod]) {?>
+<?php foreach ($compiledEntries->getContainerIdentifierMappedMethodResolve() as ['id' => $id, 'serviceMethod' => $serviceMethod]) {?>
             <?php echo \var_export($id, true); ?> => <?php echo \var_export($serviceMethod, true); ?>,
 <?php } ?>
             default => false,
         };
     }
 
-<?php foreach ($this->compiledEntries->getCompiledEntries() as ['id' => $id, 'serviceMethod' => $method , 'entry' => $compiledEntry]) {?>
+<?php foreach ($compiledEntries->getCompiledEntries() as ['id' => $id, 'serviceMethod' => $method , 'entry' => $compiledEntry]) {?>
 
     // container identifier <?php echo \var_export($id, true).PHP_EOL; ?>
     private function <?php echo $method; ?>(): <?php echo $compiledEntry->getReturnType(); ?>

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 // Template for compiled container.
 /** @var \Kaspi\DiContainer\Compiler\ContainerCompiler $this */
 echo '<?php';
-$definitions = $this->diContainerDefinitions;
+$container = $this->diContainerDefinitions->getContainer();
 $config = $this->diContainerDefinitions->getContainer()->getConfig();
 $compiledEntries = $this->compiledEntries;
 $runtimeDefinitions = $this->runtimeDefinitions;
@@ -56,9 +56,9 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
                     return <?php echo \var_export($config->isUseAttribute(), true); ?>;
                 }
             },
-<?php if ($definitions->getContainer()->getRemovedDefinitionIds()->valid()) { ?>
+<?php if ($container->getRemovedDefinitionIds()->valid()) { ?>
             removedDefinitionIds: (static function (): \Generator {
-<?php foreach ($definitions->getContainer()->getRemovedDefinitionIds() as $id => $v) {?>
+<?php foreach ($container->getRemovedDefinitionIds() as $id => $v) {?>
                 <?php echo \sprintf('yield %s => true;'.PHP_EOL, \var_export($id, true))?>
 <?php } ?>
             })()

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\DiDefinition;
+
+use Kaspi\DiContainer\Exception\DiDefinitionException;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
+
+use function rtrim;
+use function sprintf;
+
+final class DiDefinitionRuntime implements DiDefinitionNoArgumentsInterface, DiDefinitionRuntimeInterface
+{
+    private object $definition;
+
+    /**
+     * @param class-string|non-empty-string $containerIdentifier
+     */
+    public function __construct(
+        private readonly string $containerIdentifier,
+        private readonly ?string $message = null,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return $this->containerIdentifier;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function resolve(DiContainerInterface $container, mixed $context = null): object
+    {
+        if (!isset($this->definition)) {
+            $additionalMessage = $this->message ?? 'You should replace the value of "runtime definition" in the runtime container using the DiContainerInterface::set() method.';
+
+            throw new DiDefinitionException(
+                rtrim(
+                    sprintf('The "runtime definition" cannot be resolved. %s', $additionalMessage)
+                )
+            );
+        }
+
+        return $this->definition;
+    }
+
+    public function getDefinition(): ?object
+    {
+        return $this->definition ?? null;
+    }
+
+    public function setDefinition(object $definition): void
+    {
+        $this->definition = $definition;
+    }
+}

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -11,6 +11,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 
 use function rtrim;
 use function sprintf;
+use function var_export;
 
 final class DiDefinitionRuntime implements DiDefinitionNoArgumentsInterface, DiDefinitionRuntimeInterface
 {
@@ -37,11 +38,11 @@ final class DiDefinitionRuntime implements DiDefinitionNoArgumentsInterface, DiD
     public function resolve(DiContainerInterface $container, mixed $context = null): object
     {
         if (!isset($this->definition)) {
-            $additionalMessage = $this->message ?? 'You should replace the value of "runtime definition" in the runtime container using the DiContainerInterface::set() method.';
+            $additionalMessage = $this->message ?? sprintf('You should replace the value of definition in the runtime container using the method DiContainerInterface::set(%s, $objectInstance).', var_export($this->containerIdentifier, true));
 
             throw new DiDefinitionException(
                 rtrim(
-                    sprintf('The "runtime definition" cannot be resolved. %s', $additionalMessage)
+                    sprintf('The runtime definition with container identifier %s cannot be resolved. %s', var_export($this->containerIdentifier, true), $additionalMessage)
                 )
             );
         }

--- a/src/DiContainer/Interfaces/DiContainerSetterInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerSetterInterface.php
@@ -14,6 +14,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 
 interface DiContainerSetterInterface
 {
@@ -23,6 +24,7 @@ interface DiContainerSetterInterface
      *
      * @throws ContainerAlreadyRegisteredExceptionInterface
      * @throws ContainerIdentifierExceptionInterface
+     * @throws DiDefinitionExceptionInterface
      */
     public function set(string $id, mixed $definition): static;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionRuntimeInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionRuntimeInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+/**
+ * Some container definitions cannot be specified in configuration files because they are evaluated at runtime.
+ *
+ * A definition implementing the `DiDefinitionRuntimeInterface` interface does not specify a class or object,
+ * it only provides the container identifier.
+ *
+ * This definition should be replaced by other available definitions with the same container identifier.
+ */
+interface DiDefinitionRuntimeInterface extends DiDefinitionIdentifierInterface, DiDefinitionInterface
+{
+    public function getDefinition(): ?object;
+
+    /**
+     * Runtime definition value.
+     */
+    public function setDefinition(object $definition): void;
+
+    /**
+     * Additional message for definition.
+     */
+    public function getMessage(): ?string;
+}

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -8,16 +8,20 @@ use Closure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Exception\SourceDefinitionsMutableException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
 use Kaspi\DiContainer\Interfaces\SourceDefinitionsMutableInterface;
 use Traversable;
 
 use function get_debug_type;
+use function is_object;
 use function is_string;
 use function sprintf;
 use function var_export;
@@ -57,24 +61,38 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
     /**
      * @throws ContainerIdentifierExceptionInterface
      * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws DiDefinitionExceptionInterface
      */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $identifier = Helper::getContainerIdentifier($offset, $value);
 
         if ($this->offsetExists($identifier)) {
-            throw new ContainerAlreadyRegisteredException(
-                sprintf('The container identifier "%s" already registered in the source. Definition type: "%s".', $identifier, get_debug_type($value))
-            );
+            $definition = $this->definitions()[$identifier];
+
+            if (!$definition instanceof DiDefinitionRuntimeInterface) {
+                throw new ContainerAlreadyRegisteredException(
+                    sprintf('The container identifier "%s" already registered in the source. Definition type: "%s".', $identifier, get_debug_type($value))
+                );
+            }
+
+            if (!is_object($value)) {
+                throw new DiDefinitionException(
+                    sprintf('The runtime definition with the identifier %s must be specified as an object. Got value type "%s".', var_export($identifier, true), get_debug_type($value))
+                );
+            }
+
+            $definition->setDefinition($value);
+
+            return;
         }
 
-        $definition = match (true) {
+        $this->definitions()[$identifier] = match (true) {
             $value instanceof DiDefinitionInterface => $value,
             $value instanceof Closure => new DiDefinitionCallable($value),
             default => new DiDefinitionValue($value)
         };
 
-        $this->definitions()[$identifier] = $definition;
         unset($this->removedDefinitionIds()[$identifier]);
     }
 

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -11,6 +11,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
@@ -100,5 +101,15 @@ if (!function_exists('Kaspi\DiContainer\diParameterRuntime')) { // @codeCoverage
     function diParameterRuntime(string $name = '', ?string $message = null): DiDefinitionNoArgumentsInterface
     {
         return new DiDefinitionParameterRuntime($name, $message);
+    }
+} // @codeCoverageIgnore
+
+if (!function_exists('Kaspi\DiContainer\diRuntime')) { // @codeCoverageIgnore
+    /**
+     * @param non-empty-string $containerIdentifier
+     */
+    function diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoArgumentsInterface
+    {
+        return new DiDefinitionRuntime($containerIdentifier, $message);
     }
 } // @codeCoverageIgnore

--- a/tests/Compiler/Compiler/CompileTest.php
+++ b/tests/Compiler/Compiler/CompileTest.php
@@ -14,9 +14,11 @@ use Kaspi\DiContainer\Compiler\DiDefinitionTransformer;
 use Kaspi\DiContainer\Compiler\Helper;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerNullConfig;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Enum\InvalidBehaviorCompileEnum;
 use Kaspi\DiContainer\Exception\NotFoundException;
+use Kaspi\DiContainer\Interfaces\Compiler\CompiledEntriesInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\DiDefinitionTransformerInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\IdsIteratorInterface;
@@ -27,9 +29,11 @@ use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
+use stdClass;
 
 use function bin2hex;
 use function random_bytes;
@@ -51,6 +55,9 @@ use function random_bytes;
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(CompiledEntries::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(\Kaspi\DiContainer\Helper::class)]
+#[CoversFunction('Kaspi\DiContainer\diRuntime')]
 class CompileTest extends TestCase
 {
     private DiDefinitionTransformerInterface $mockTransformer;
@@ -141,5 +148,50 @@ class CompileTest extends TestCase
 
         self::assertTrue($reflectionClass->hasMethod('resolve_container'));
         self::assertTrue($reflectionClass->hasMethod('resolve_container1'));
+    }
+
+    public function testCompileParamsForRuntimeDefinition(): void
+    {
+        $containerMock = $this->createMock(DiContainerInterface::class);
+        $containerMock->method('getDefinitions')
+            ->willReturnCallback(static function (): Generator {
+                yield 'foo' => new DiDefinitionRuntime('foo');
+            })
+        ;
+
+        $idsIter = $this->createMock(IdsIteratorInterface::class);
+        $containerDefinitions = new DiContainerDefinitions($containerMock, $idsIter);
+        $transformerMock = $this->createMock(DiDefinitionTransformerInterface::class);
+        $compiledEntriesMock = $this->createMock(CompiledEntriesInterface::class);
+
+        $containerName = 'Container'.bin2hex(random_bytes(8));
+        $containerClass = __NAMESPACE__.'\\'.$containerName;
+
+        $compiler = new ContainerCompiler(
+            $containerClass,
+            $containerDefinitions,
+            $transformerMock,
+            $compiledEntriesMock,
+            InvalidBehaviorCompileEnum::ExceptionOnCompile,
+        );
+
+        $containerFile = $containerName.'.php';
+
+        vfsStream::setup(structure: [
+            $containerFile => $compiler->compile(),
+        ]);
+
+        require_once vfsStream::url('root/'.$containerFile);
+
+        $container = new $containerClass();
+
+        self::assertTrue($container->has('foo'));
+        self::assertFalse($container->has('bar'));
+
+        $instance = new stdClass();
+
+        $container->set('foo', $instance);
+
+        self::assertSame($instance, $container->get('foo'));
     }
 }

--- a/tests/Compiler/DiDefinitionTransformer/DiDefinitionTransformerTest.php
+++ b/tests/Compiler/DiDefinitionTransformer/DiDefinitionTransformerTest.php
@@ -15,6 +15,7 @@ use Kaspi\DiContainer\Compiler\CompilableDefinition\ProxyClosureEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\TaggedAsEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ValueEntry;
 use Kaspi\DiContainer\Compiler\DiDefinitionTransformer;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Interfaces\Compiler\DiContainerDefinitionsInterface;
 use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
@@ -29,6 +30,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionValueInterface;
 use Kaspi\DiContainer\Interfaces\Finder\FinderClosureCodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -119,14 +121,6 @@ class DiDefinitionTransformerTest extends TestCase
         ];
     }
 
-    public function testUnsupportedDefinitionWithoutFallback(): void
-    {
-        $this->expectException(DefinitionCompileExceptionInterface::class);
-        $this->expectExceptionMessage('Unsupported definition type "stdClass"');
-
-        $this->transformer->transform(new stdClass(), $this->diContainerDefinitions);
-    }
-
     public function testUnsupportedDefinitionWithFallback(): void
     {
         $compilableDefinotion = $this->transformer->transform(
@@ -141,5 +135,15 @@ class DiDefinitionTransformerTest extends TestCase
     public function testGetClosureParser(): void
     {
         self::assertInstanceOf(FinderClosureCodeInterface::class, $this->transformer->getClosureParser());
+    }
+
+    #[TestWith([new DiDefinitionRuntime('foo'), 'Unsupported definition type "Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime"'])]
+    #[TestWith([new stdClass(), 'Unsupported definition type "stdClass"'])]
+    public function testUnsupportedDefinition(mixed $def, string $expectMsg): void
+    {
+        $this->expectException(DefinitionCompileExceptionInterface::class);
+        $this->expectExceptionMessage($expectMsg);
+
+        $this->transformer->transform($def, $this->diContainerDefinitions);
     }
 }

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
@@ -36,7 +36,7 @@ class DiDefinitionRuntimeTest extends TestCase
     public function testCannotResolveWithoutDefinition(): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessage('The "runtime definition" cannot be resolved');
+        $this->expectExceptionMessage('The runtime definition with container identifier \'service.foo\' cannot be resolved.');
 
         (new DiDefinitionRuntime('service.foo'))
             ->resolve($this->createMock(DiContainerInterface::class))

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionRuntime;
+
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(DiDefinitionRuntime::class)]
+class DiDefinitionRuntimeTest extends TestCase
+{
+    #[TestWith([null, null])]
+    #[TestWith(['Oops!', 'Oops!'])]
+    public function testAdditionalMessage(?string $msg, ?string $partOfExpectMessage): void
+    {
+        $d = new DiDefinitionRuntime('x', $msg);
+
+        self::assertEquals($partOfExpectMessage, $d->getMessage());
+    }
+
+    public function testContainerIdentifier(): void
+    {
+        $d = new DiDefinitionRuntime('service.foo');
+
+        self::assertEquals('service.foo', $d->getIdentifier());
+    }
+
+    public function testCannotResolveWithoutDefinition(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('The "runtime definition" cannot be resolved');
+
+        (new DiDefinitionRuntime('service.foo'))
+            ->resolve($this->createMock(DiContainerInterface::class))
+        ;
+    }
+
+    public function testDefinitionNotSetYet(): void
+    {
+        self::assertNull((new DiDefinitionRuntime('service.foo'))->getDefinition());
+    }
+
+    public function testSetAndGetDefinitionAsObject(): void
+    {
+        $object = (object) ['foo' => 'bar'];
+
+        $d = new DiDefinitionRuntime('service.foo');
+        $d->setDefinition($object);
+
+        self::assertSame($object, $d->getDefinition());
+        self::assertSame($object, $d->resolve($this->createMock(DiContainerInterface::class)));
+    }
+}

--- a/tests/Function/HelperFunctionTest.php
+++ b/tests/Function/HelperFunctionTest.php
@@ -11,6 +11,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameter;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionParameterRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionProxyClosure;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Helper;
@@ -30,6 +31,7 @@ use function Kaspi\DiContainer\diGet;
 use function Kaspi\DiContainer\diParameter;
 use function Kaspi\DiContainer\diParameterRuntime;
 use function Kaspi\DiContainer\diProxyClosure;
+use function Kaspi\DiContainer\diRuntime;
 use function Kaspi\DiContainer\diTaggedAs;
 
 /**
@@ -51,6 +53,8 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversFunction('Kaspi\DiContainer\diParameter')]
 #[CoversClass(DiDefinitionParameterRuntime::class)]
 #[CoversFunction('Kaspi\DiContainer\diParameterRuntime')]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversFunction('Kaspi\DiContainer\diRuntime')]
 class HelperFunctionTest extends TestCase
 {
     public function testFunctiondiGet(): void
@@ -147,5 +151,16 @@ class HelperFunctionTest extends TestCase
 
         self::assertEquals($expectDefinition, $p->getDefinition());
         self::assertStringContainsString($expectMessage, $p->getMessage());
+    }
+
+    #[TestWith(['foo', 'foo'])]
+    #[TestWith(['foo', null])]
+    public function testDiDefinitionRuntime(string $identifier, ?string $message): void
+    {
+        $d = diRuntime($identifier, $message);
+
+        self::assertInstanceOf(DiDefinitionRuntime::class, $d);
+        self::assertEquals($identifier, $d->getIdentifier());
+        self::assertEquals($message, $d->getMessage());
     }
 }

--- a/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInCompiledContainerTest.php
+++ b/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInCompiledContainerTest.php
@@ -6,8 +6,11 @@ namespace Tests\Integration\DiDefinitionRuntime;
 
 use Kaspi\DiContainer\DiContainerBuilder;
 use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\Interfaces\DiContainerBuilderInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerBuilderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Tests\Integration\DiDefinitionRuntime\Fixtures\Foo;
@@ -22,21 +25,34 @@ use function random_bytes;
 #[CoversNothing]
 class DiDefinitionRuntimeInCompiledContainerTest extends TestCase
 {
-    public function testReplaceRuntimeDefinitionSuccess(): void
-    {
-        vfsStream::setup('root');
-        $containerClass = __NAMESPACE__.'\Container_'.bin2hex(random_bytes(16));
+    private DiContainerBuilderInterface $builder;
+    private vfsStreamDirectory $rootDir;
 
-        $container = (new DiContainerBuilder(
+    protected function setUp(): void
+    {
+        $this->builder = new DiContainerBuilder(
             containerConfig: new DiContainerConfig(
                 useAttribute: true,
             )
-        ))
-            ->import('Tests\\', __DIR__.'/Fixtures')
+        );
+        $this->rootDir = vfsStream::setup('root');
+
+        $containerClass = __NAMESPACE__.'\Container_'.bin2hex(random_bytes(16));
+
+        $this->builder->import('Tests\\', __DIR__.'/Fixtures')
             ->load(__DIR__.'/Fixtures/services.php')
             ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
-            ->build()
         ;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->builder, $this->rootDir);
+    }
+
+    public function testReplaceRuntimeDefinitionSuccess(): void
+    {
+        $container = $this->builder->build();
 
         self::assertTrue($container->has('service.foo'));
 
@@ -55,23 +71,37 @@ class DiDefinitionRuntimeInCompiledContainerTest extends TestCase
         $this->expectException(DiDefinitionExceptionInterface::class);
         $this->expectExceptionMessage('The runtime definition with container identifier \'service.foo\' cannot be resolved');
 
-        vfsStream::setup('root');
-        $containerClass = __NAMESPACE__.'\Container_'.bin2hex(random_bytes(16));
-
-        // The definition at container identifier `'service.foo'` not replaced via `$container->set('service.foo', $instance)`
-        $container = (new DiContainerBuilder(
-            containerConfig: new DiContainerConfig(
-                useAttribute: true,
-            )
-        ))
-            ->import('Tests\\', __DIR__.'/Fixtures')
-            ->load(__DIR__.'/Fixtures/services.php')
-            ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
-            ->build()
-        ;
+        $container = $this->builder->build();
 
         self::assertTrue($container->has('service.foo'));
 
         $container->get(FooAttr::class);
+    }
+
+    public function testDiDefinitionRuntimeOnParameter(): void
+    {
+        $this->expectException(ContainerBuilderExceptionInterface::class);
+        $this->expectExceptionMessage('Cannot compile arguments');
+
+        vfsStream::newFile('redefine_service.php')
+            ->setContent('<?php
+use Tests\Integration\DiDefinitionRuntime\Fixtures\Foo;
+
+return static function (\Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface $configurator) {
+    $configurator->setDefinition(
+        Foo::class,
+        \Kaspi\DiContainer\diAutowire(Foo::class)
+            ->bindArguments(
+                service: \Kaspi\DiContainer\diRuntime("service.foo")
+            )
+    );
+};
+')
+            ->at($this->rootDir)
+        ;
+
+        $this->builder->load(vfsStream::url('root/redefine_service.php'));
+
+        $this->builder->build();
     }
 }

--- a/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInCompiledContainerTest.php
+++ b/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInCompiledContainerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime;
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\DiDefinitionRuntime\Fixtures\Foo;
+use Tests\Integration\DiDefinitionRuntime\Fixtures\FooAttr;
+
+use function bin2hex;
+use function random_bytes;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+class DiDefinitionRuntimeInCompiledContainerTest extends TestCase
+{
+    public function testReplaceRuntimeDefinitionSuccess(): void
+    {
+        vfsStream::setup('root');
+        $containerClass = __NAMESPACE__.'\Container_'.bin2hex(random_bytes(16));
+
+        $container = (new DiContainerBuilder(
+            containerConfig: new DiContainerConfig(
+                useAttribute: true,
+            )
+        ))
+            ->import('Tests\\', __DIR__.'/Fixtures')
+            ->load(__DIR__.'/Fixtures/services.php')
+            ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
+            ->build()
+        ;
+
+        self::assertTrue($container->has('service.foo'));
+
+        $instance = (object) ['foo' => 'Service bar'];
+
+        $container->set('service.foo', $instance);
+
+        // service configured via php attribute `Inject`
+        self::assertSame($instance, $container->get(FooAttr::class)->service);
+        // service configured via `bindArguments()`
+        self::assertSame($instance, $container->get(Foo::class)->service);
+    }
+
+    public function testReplaceRuntimeDefinitionFail(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('The runtime definition with container identifier \'service.foo\' cannot be resolved');
+
+        vfsStream::setup('root');
+        $containerClass = __NAMESPACE__.'\Container_'.bin2hex(random_bytes(16));
+
+        // The definition at container identifier `'service.foo'` not replaced via `$container->set('service.foo', $instance)`
+        $container = (new DiContainerBuilder(
+            containerConfig: new DiContainerConfig(
+                useAttribute: true,
+            )
+        ))
+            ->import('Tests\\', __DIR__.'/Fixtures')
+            ->load(__DIR__.'/Fixtures/services.php')
+            ->compileToFile(vfsStream::url('root/'), $containerClass, isExclusiveLockFile: false)
+            ->build()
+        ;
+
+        self::assertTrue($container->has('service.foo'));
+
+        $container->get(FooAttr::class);
+    }
+}

--- a/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInRuntimeContainerTest.php
+++ b/tests/Integration/DiDefinitionRuntime/DiDefinitionRuntimeInRuntimeContainerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime;
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\DiDefinitionRuntime\Fixtures\Foo;
+use Tests\Integration\DiDefinitionRuntime\Fixtures\FooAttr;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+class DiDefinitionRuntimeInRuntimeContainerTest extends TestCase
+{
+    public function testReplaceRuntimeDefinitionSuccess(): void
+    {
+        $container = (new DiContainerBuilder(
+            containerConfig: new DiContainerConfig(
+                useAttribute: true,
+            )
+        ))
+            ->import('Tests\\', __DIR__.'/Fixtures')
+            ->load(__DIR__.'/Fixtures/services.php')
+            ->build()
+        ;
+
+        $instance = (object) ['foo' => 'Service bar'];
+
+        $container->set('service.foo', $instance);
+
+        // service configured via php attribute `Inject`
+        self::assertSame($instance, $container->get(FooAttr::class)->service);
+        // service configured via `bindArguments()`
+        self::assertSame($instance, $container->get(Foo::class)->service);
+    }
+
+    public function testReplaceRuntimeDefinitionFail(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+
+        // The definition at container identifier `'service.foo'` not replaced via `$container->set('service.foo', $instance)`
+        $container = (new DiContainerBuilder(
+            containerConfig: new DiContainerConfig(
+                useAttribute: true,
+            )
+        ))
+            ->import('Tests\\', __DIR__.'/Fixtures')
+            ->load(__DIR__.'/Fixtures/services.php')
+            ->build()
+        ;
+
+        $container->get(FooAttr::class);
+    }
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures/Bar.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures;
+
+final class Bar {}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures/Foo.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures;
+
+final class Foo
+{
+    public function __construct(public readonly Bar $bar, public readonly object $service) {}
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures/FooAttr.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures/FooAttr.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Inject;
+
+final class FooAttr
+{
+    public function __construct(
+        public readonly Bar $bar,
+        #[Inject('service.foo')]
+        public readonly object $service
+    ) {}
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures/services.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures/services.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use Tests\Integration\DiDefinitionRuntime\Fixtures\Foo;
+
+use function Kaspi\DiContainer\diAutowire;
+use function Kaspi\DiContainer\diGet;
+use function Kaspi\DiContainer\diRuntime;
+
+return static function (DefinitionsConfiguratorInterface $configurator): Generator {
+    yield diRuntime('service.foo');
+
+    yield diAutowire(Foo::class)
+        ->bindArguments(service: diGet('service.foo'))
+    ;
+};

--- a/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
@@ -6,10 +6,12 @@ namespace Tests\SourceDefinitionsMutable;
 
 use Generator;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
@@ -27,6 +29,7 @@ use function array_keys;
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionValue::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(Helper::class)]
 class ImmediateSourceDefinitionsMutableTest extends TestCase
 {
@@ -211,5 +214,28 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         // set service id and remove if exist in `removedDefinitionIds`
         $s['service.foo'] = 'Service foo';
         self::assertFalse($s->isRemovedDefinition('service.foo'));
+    }
+
+    public function testReplaceRuntimeDefinitionSuccess(): void
+    {
+        $s = new ImmediateSourceDefinitionsMutable([
+            new DiDefinitionRuntime('service.foo'),
+        ]);
+
+        $s['service.foo'] = $instance = (object) ['bar' => 'Service bar'];
+
+        self::assertSame($instance, $s['service.foo']->getDefinition());
+    }
+
+    public function testReplaceRuntimeDefinitionFail(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('The runtime definition with the identifier \'service.foo\' must be specified as an object.');
+
+        $s = new ImmediateSourceDefinitionsMutable([
+            new DiDefinitionRuntime('service.foo'),
+        ]);
+
+        $s['service.foo'] = ['bar' => 'Service bar'];
     }
 }

--- a/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
@@ -6,10 +6,12 @@ namespace Tests\SourceDefinitionsMutable;
 
 use Generator;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\DeferredSourceDefinitionsMutable;
@@ -26,6 +28,7 @@ use function array_keys;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(DeferredSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(Helper::class)]
 class SourceDefinitionsMutableTest extends TestCase
@@ -213,5 +216,28 @@ class SourceDefinitionsMutableTest extends TestCase
         );
 
         self::assertTrue($s->isRemovedDefinition('service.foo'));
+    }
+
+    public function testReplaceRuntimeDefinitionSuccess(): void
+    {
+        $s = new DeferredSourceDefinitionsMutable(
+            static fn () => yield new DiDefinitionRuntime('service.foo')
+        );
+
+        $s['service.foo'] = $instance = (object) ['bar' => 'Service bar'];
+
+        self::assertSame($instance, $s['service.foo']->getDefinition());
+    }
+
+    public function testReplaceRuntimeDefinitionFail(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('The runtime definition with the identifier \'service.foo\' must be specified as an object.');
+
+        $s = new DeferredSourceDefinitionsMutable(
+            static fn () => yield new DiDefinitionRuntime('service.foo')
+        );
+
+        $s['service.foo'] = ['bar' => 'Service bar'];
     }
 }


### PR DESCRIPTION
Resolve #511 

- [x] Реализация интерфейса `DiDefinitionRuntimeInterface`
- [x] Хелпер функция `diRuntime()`
- [x] `DeferredSourceDefinitionsMutable` и `ImmediateSourceDefinitionsMutable` должны заменять определения с типом `DiDefinitionRuntimeInterface`.
- [x] Компиляция `DiDefinitionRuntimeInterface`
- Тесты для определения
  - [x] Тесты для `DiDefinitionRuntimeInterface`
  - [x] Тест для `DeferredSourceDefinitionsMutable` при обновлении определения
  - [x] Тест для `ImmediateSourceDefinitionsMutable` при обновлении определения
  - [x] Тесты для runtime контейнера
  - [x] Тесты для скомпилированного контейнера
- [x] Обновление документации
