### PR TITLE
DiDefinitionIdentifierInterface – check non empty string

### DIFF
--- a/src/DiContainer/Helper.php
+++ b/src/DiContainer/Helper.php
@@ -82,7 +82,8 @@ final class Helper
             return $identifier;
         }
 
-        if ($definition instanceof DiDefinitionIdentifierInterface) {
+        if ($definition instanceof DiDefinitionIdentifierInterface
+            && '' !== $definition->getIdentifier()) {
             return $definition->getIdentifier();
         }
 

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -8,9 +8,8 @@ use Closure;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
-use Kaspi\DiContainer\Exception\ContainerIdentifierException;
 use Kaspi\DiContainer\Exception\SourceDefinitionsMutableException;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
+use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
@@ -61,13 +60,7 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
      */
     public function offsetSet(mixed $offset, mixed $value): void
     {
-        $identifier = match (true) {
-            is_string($offset) && '' !== $offset => $offset,
-            $value instanceof DiDefinitionIdentifierInterface => $value->getIdentifier(),
-            default => throw new ContainerIdentifierException(
-                sprintf('Definition identifier must be a non-empty string. Definition type "%s".', get_debug_type($value))
-            )
-        };
+        $identifier = Helper::getContainerIdentifier($offset, $value);
 
         if ($this->offsetExists($identifier)) {
             throw new ContainerAlreadyRegisteredException(

--- a/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
+++ b/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
@@ -22,6 +22,7 @@ use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Finder\FinderFile;
 use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
 use Kaspi\DiContainer\FinderFullyQualifiedNameCollection;
+use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Parameters\DeferredSourceParameters;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
@@ -63,6 +64,7 @@ use function random_bytes;
 #[CoversClass(FinderFullyQualifiedName::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
 #[CoversClass(DeferredSourceParameters::class)]
+#[CoversClass(Helper::class)]
 class RemovedDefinitionIdsTest extends TestCase
 {
     public function testRemovedDefinitionIds(): void

--- a/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
@@ -7,6 +7,7 @@ namespace Tests\SourceDefinitionsMutable;
 use Generator;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
+use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
@@ -26,6 +27,7 @@ use function array_keys;
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionValue::class)]
+#[CoversClass(Helper::class)]
 class ImmediateSourceDefinitionsMutableTest extends TestCase
 {
     #[DataProvider('provideIterableType')]

--- a/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
@@ -7,6 +7,7 @@ namespace Tests\SourceDefinitionsMutable;
 use Generator;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
+use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
@@ -26,6 +27,7 @@ use function array_keys;
 #[CoversClass(DeferredSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionValue::class)]
+#[CoversClass(Helper::class)]
 class SourceDefinitionsMutableTest extends TestCase
 {
     #[DataProvider('provideIterableType')]


### PR DESCRIPTION
Resolve #520 