### PR TITLE
Uses result once from check type in `DefinitionsLoader::getDefinitionsFromFile()`

### DIFF
--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -655,8 +655,8 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
             return;
         }
 
-        if (is_callable($content) && is_iterable($content($this->definitionsConfigurator()))) {
-            yield from $content($this->definitionsConfigurator());
+        if (is_callable($content) && is_iterable($definitions = $content($this->definitionsConfigurator()))) {
+            yield from $definitions;
 
             unset($this->circularLoadFromFileWatcher[$srcFile]);
 


### PR DESCRIPTION
Resolve #517 