### PR TITLE
Refactor `SourceDefinitionsMutableInterface`.

### DIFF
--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -133,7 +133,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
     public function has(string $id): bool
     {
-        return isset($this->definitions[$id])
+        return $this->definitions->has($id)
             || array_key_exists($id, $this->resolved)
             || $this->isContainer($id)
             || $this->hasViaZeroConfigurationDefinition($id);
@@ -145,7 +145,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             throw new ContainerAlreadyRegisteredException(id: $id);
         }
 
-        $this->definitions->offsetSet($id, $definition);
+        $this->definitions->set($id, $definition);
 
         return $this;
     }
@@ -199,7 +199,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     public function getDefinitions(): iterable
     {
-        foreach ($this->definitions as $id => $definition) {
+        foreach ($this->definitions->getIterator() as $id => $definition) {
             if (!$this->isContainer($id)) {
                 yield $id => $definition;
             }
@@ -311,8 +311,8 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     protected function resolveDefinition(string $id): DiDefinitionAutowireInterface|DiDefinitionInterface|DiDefinitionLinkInterface|DiDefinitionSingletonInterface|DiDefinitionTaggedAsInterface
     {
-        if (isset($this->definitions[$id])) {
-            return $this->definitions[$id]; // @phpstan-ignore return.type
+        if ($this->definitions->has($id)) {
+            return $this->definitions->get($id);
         }
 
         if (isset($this->diResolvedDefinition[$id])) {

--- a/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
+++ b/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
@@ -4,13 +4,30 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces;
 
-use ArrayAccess;
 use IteratorAggregate;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
 use Traversable;
 
-interface SourceDefinitionsMutableInterface extends ArrayAccess, IteratorAggregate
+interface SourceDefinitionsMutableInterface extends IteratorAggregate
 {
+    public function has(string $id): bool;
+
+    /**
+     * @throws SourceDefinitionsMutableExceptionInterface
+     */
+    public function get(string $id): DiDefinitionInterface;
+
+    /**
+     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierExceptionInterface
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function set(int|string $id, mixed $value): void;
+
     /**
      * @return Traversable<non-empty-string, DiDefinitionInterface>
      */

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -13,16 +13,11 @@ use Kaspi\DiContainer\Exception\SourceDefinitionsMutableException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\SourceDefinitionsMutableExceptionInterface;
 use Kaspi\DiContainer\Interfaces\SourceDefinitionsMutableInterface;
 use Traversable;
 
 use function get_debug_type;
 use function is_object;
-use function is_string;
 use function sprintf;
 use function var_export;
 
@@ -33,41 +28,31 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
         yield from $this->definitions();
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function has(string $id): bool
     {
-        if (is_string($offset) && '' !== $offset) {
-            return isset($this->definitions()[$offset]);
+        if ('' !== $id) {
+            return isset($this->definitions()[$id]);
         }
 
         return false;
     }
 
-    /**
-     * @throws SourceDefinitionsMutableExceptionInterface
-     */
-    public function offsetGet(mixed $offset): DiDefinitionInterface
+    public function get(string $id): DiDefinitionInterface
     {
-        if (!$this->offsetExists($offset)) {
-            $message = is_string($offset)
-                ? sprintf('Unregistered the container identifier "%s" in the source.', $offset)
-                : sprintf('Unsupported identifier type "%s"', get_debug_type($offset));
-
-            throw new SourceDefinitionsMutableException($message);
+        if (!$this->has($id)) {
+            throw new SourceDefinitionsMutableException(
+                sprintf('Unregistered the container identifier %s in the source.', var_export($id, true))
+            );
         }
 
-        return $this->definitions()[$offset]; // @phpstan-ignore offsetAccess.invalidOffset
+        return $this->definitions()[$id];
     }
 
-    /**
-     * @throws ContainerIdentifierExceptionInterface
-     * @throws ContainerAlreadyRegisteredExceptionInterface
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function set(int|string $id, mixed $value): void
     {
-        $identifier = Helper::getContainerIdentifier($offset, $value);
+        $identifier = Helper::getContainerIdentifier($id, $value);
 
-        if ($this->offsetExists($identifier)) {
+        if ($this->has($identifier)) {
             $definition = $this->definitions()[$identifier];
 
             if (!$definition instanceof DiDefinitionRuntimeInterface) {
@@ -95,21 +80,6 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
         };
 
         unset($this->removedDefinitionIds()[$identifier]);
-    }
-
-    /**
-     * @throws ContainerIdentifierExceptionInterface
-     * @throws SourceDefinitionsMutableExceptionInterface
-     */
-    public function offsetUnset(mixed $offset): void
-    {
-        $identifier = is_string($offset)
-            ? $offset
-            : var_export($offset, true);
-
-        throw new SourceDefinitionsMutableException(
-            sprintf('Definitions in the source are non-removable. Operation using the container identifier "%s".', $identifier)
-        );
     }
 
     public function getRemovedDefinitionIds(): iterable

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -30,22 +30,16 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
 
     public function has(string $id): bool
     {
-        if ('' !== $id) {
-            return isset($this->definitions()[$id]);
-        }
-
-        return false;
+        return !('' === $id) && isset($this->definitions()[$id]);
     }
 
     public function get(string $id): DiDefinitionInterface
     {
-        if (!$this->has($id)) {
-            throw new SourceDefinitionsMutableException(
+        return $this->has($id)
+            ? $this->definitions()[$id]
+            : throw new SourceDefinitionsMutableException(
                 sprintf('Unregistered the container identifier %s in the source.', var_export($id, true))
             );
-        }
-
-        return $this->definitions()[$id];
     }
 
     public function set(int|string $id, mixed $value): void

--- a/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
@@ -46,7 +46,7 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
             $this->removedDefinitionIds = [];
 
             foreach (($this->sourceDefinitions)() as $identifier => $sourceDefinition) {
-                $this->offsetSet($identifier, $sourceDefinition);
+                $this->set($identifier, $sourceDefinition);
             }
 
             if (null !== $this->sourceRemovedDefinitionIds) {

--- a/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
@@ -7,6 +7,7 @@ namespace Kaspi\DiContainer\SourceDefinitions;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 
 final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsMutable
 {
@@ -20,7 +21,9 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
      * @param iterable<non-empty-string|non-negative-int, mixed> $sourceDefinitions
      * @param iterable<class-string|non-empty-string, mixed>     $sourceRemovedDefinitionIds
      *
-     * @throws ContainerAlreadyRegisteredExceptionInterface|ContainerIdentifierExceptionInterface
+     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierExceptionInterface
+     * @throws DiDefinitionExceptionInterface
      */
     public function __construct(iterable $sourceDefinitions, iterable $sourceRemovedDefinitionIds = [])
     {
@@ -28,7 +31,7 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
         $this->removedDefinitionIds = [];
 
         foreach ($sourceDefinitions as $identifier => $sourceDefinition) {
-            $this->offsetSet($identifier, $sourceDefinition);
+            $this->set($identifier, $sourceDefinition);
         }
 
         foreach ($sourceRemovedDefinitionIds as $identifier => $v) {

--- a/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
@@ -19,7 +19,6 @@ use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 use function array_keys;
 
@@ -38,7 +37,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
     #[DataProvider('provideIterableType')]
     public function testConstructorIterableType(iterable $src, string $id): void
     {
-        self::assertTrue(isset((new ImmediateSourceDefinitionsMutable($src))[$id]));
+        self::assertTrue((new ImmediateSourceDefinitionsMutable($src))->has($id));
     }
 
     public static function provideIterableType(): Generator
@@ -70,33 +69,24 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
             'service.null' => null,
         ]);
 
-        self::assertTrue(isset($s['service.null']));
-        self::assertFalse(isset($s['service.not_exist']));
+        self::assertTrue($s->has('service.null'));
+        self::assertFalse($s->has('service.not_exist'));
     }
 
     public function testGetUndefinedKey(): void
     {
         $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Unregistered the container identifier "service.foo" in the source.');
+        $this->expectExceptionMessage('Unregistered the container identifier \'service.foo\' in the source.');
 
         $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Lorem ipsum']);
-        $s['service.foo'];
-    }
-
-    public function testUnsetNotAvailable(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable. Operation using the container identifier "service.bar".');
-
-        $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Lorem ipsum']);
-        unset($s['service.bar']);
+        $s->get('service.foo');
     }
 
     public function testSetSuccess(): void
     {
         $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Service bar']);
-        $s['service.baz'] = 'Service baz';
-        $s[] = new DiDefinitionAutowire(self::class);
+        $s->set('service.baz', 'Service baz');
+        $s->set(0, new DiDefinitionAutowire(self::class));
 
         self::assertEquals(
             [
@@ -114,7 +104,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         $this->expectExceptionMessage('The container identifier \'service.bar\' already registered in the source.');
 
         $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Service bar']);
-        $s['service.bar'] = 'Other value';
+        $s->set('service.bar', 'Other value');
     }
 
     public function testNoneValidKeyInDefinitionsThroughConstructor(): void
@@ -139,59 +129,13 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         new ImmediateSourceDefinitionsMutable($defs());
     }
 
-    #[DataProvider('dataProviderWrongKeyForSetter')]
-    public function testNoneStringKeyForSetter(mixed $offset): void
+    public function testEmptyStringKeyForSetter(): void
     {
         $this->expectException(ContainerIdentifierExceptionInterface::class);
         $this->expectExceptionMessage('Definition identifier must be a non-empty string');
 
         $s = new ImmediateSourceDefinitionsMutable([]);
-        $s[$offset] = 'service value';
-    }
-
-    public static function dataProviderWrongKeyForSetter(): Generator
-    {
-        yield 'object' => [new stdClass()];
-
-        yield 'array' => [[]];
-
-        yield 'bool' => [true];
-
-        yield 'empty string' => [''];
-    }
-
-    public function testNoneStringKeyForGetter(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Unsupported identifier type "stdClass"');
-
-        $s = new ImmediateSourceDefinitionsMutable([]);
-        $s[new stdClass()];
-    }
-
-    public function testNoneStringKeyForExister(): void
-    {
-        $s = new ImmediateSourceDefinitionsMutable([]);
-
-        self::assertFalse(isset($s[new stdClass()]));
-    }
-
-    public function testNoneStringKeyForUnset(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable');
-
-        $s = new ImmediateSourceDefinitionsMutable([]);
-        unset($s[new stdClass()]);
-    }
-
-    public function testUnset(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable');
-
-        $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Service bar']);
-        unset($s['service.bar']);
+        $s->set('', 'service value');
     }
 
     public function testRemovedDefinitionIds(): void
@@ -214,7 +158,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         self::assertFalse($s->isRemovedDefinition('service.bar'));
 
         // set service id and remove if exist in `removedDefinitionIds`
-        $s['service.foo'] = 'Service foo';
+        $s->set('service.foo', 'Service foo');
         self::assertFalse($s->isRemovedDefinition('service.foo'));
     }
 
@@ -224,9 +168,9 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
             new DiDefinitionRuntime('service.foo'),
         ]);
 
-        $s['service.foo'] = $instance = (object) ['bar' => 'Service bar'];
+        $s->set('service.foo', $instance = (object) ['bar' => 'Service bar']);
 
-        self::assertSame($instance, $s['service.foo']->getDefinition());
+        self::assertSame($instance, $s->get('service.foo')->getDefinition());
     }
 
     public function testReplaceRuntimeDefinitionFail(): void
@@ -238,6 +182,13 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
             new DiDefinitionRuntime('service.foo'),
         ]);
 
-        $s['service.foo'] = ['bar' => 'Service bar'];
+        $s->set('service.foo', ['bar' => 'Service bar']);
+    }
+
+    public function testHasEmptyString(): void
+    {
+        $s = new ImmediateSourceDefinitionsMutable([]);
+
+        self::assertFalse($s->has(''));
     }
 }

--- a/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/SourceDefinitionsMutableTest.php
@@ -19,7 +19,6 @@ use Kaspi\DiContainer\SourceDefinitions\DeferredSourceDefinitionsMutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 use function array_keys;
 
@@ -38,7 +37,7 @@ class SourceDefinitionsMutableTest extends TestCase
     #[DataProvider('provideIterableType')]
     public function testConstructorIterableType(iterable $src, string $id): void
     {
-        self::assertTrue(isset((new DeferredSourceDefinitionsMutable(static fn () => $src))[$id]));
+        self::assertTrue((new DeferredSourceDefinitionsMutable(static fn () => $src))->has($id));
     }
 
     public static function provideIterableType(): Generator
@@ -70,8 +69,8 @@ class SourceDefinitionsMutableTest extends TestCase
             'service.null' => null,
         ]);
 
-        self::assertTrue(isset($s['service.null']));
-        self::assertFalse(isset($s['service.not_exist']));
+        self::assertTrue($s->has('service.null'));
+        self::assertFalse($s->has('service.not_exist'));
     }
 
     public function testNoneValidKeyInDefinitionsThroughConstructor(): void
@@ -86,26 +85,17 @@ class SourceDefinitionsMutableTest extends TestCase
     public function testGetUndefinedKey(): void
     {
         $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Unregistered the container identifier "service.foo" in the source.');
+        $this->expectExceptionMessage('Unregistered the container identifier \'service.foo\' in the source.');
 
         $s = new DeferredSourceDefinitionsMutable(static fn () => ['service.bar' => 'Lorem ipsum']);
-        $s['service.foo'];
-    }
-
-    public function testUnsetNotAvailable(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable. Operation using the container identifier "service.bar".');
-
-        $s = new DeferredSourceDefinitionsMutable(static fn () => ['service.bar' => 'Lorem ipsum']);
-        unset($s['service.bar']);
+        $s->get('service.foo');
     }
 
     public function testSetSuccess(): void
     {
         $s = new DeferredSourceDefinitionsMutable(static fn () => ['service.bar' => 'Service bar']);
-        $s['service.baz'] = 'Service baz';
-        $s[] = new DiDefinitionAutowire(self::class);
+        $s->set('service.baz', 'Service baz');
+        $s->set(0, new DiDefinitionAutowire(self::class));
 
         self::assertEquals(
             [
@@ -123,63 +113,24 @@ class SourceDefinitionsMutableTest extends TestCase
         $this->expectExceptionMessage('The container identifier \'service.bar\' already registered in the source.');
 
         $s = new DeferredSourceDefinitionsMutable(static fn () => ['service.bar' => 'Service bar']);
-        $s['service.bar'] = 'Other value';
+        $s->set('service.bar', 'Other value');
     }
 
     #[DataProvider('dataProviderWrongKeyForSetter')]
-    public function testNoneStringKeyForSetter(mixed $offset): void
+    public function testNoneStringKeyForSetter(int|string $offset, mixed $value): void
     {
         $this->expectException(ContainerIdentifierExceptionInterface::class);
         $this->expectExceptionMessage('Definition identifier must be a non-empty string');
 
         $s = new DeferredSourceDefinitionsMutable(static fn () => []);
-        $s[$offset] = 'Service value';
+        $s->set($offset, $value);
     }
 
     public static function dataProviderWrongKeyForSetter(): Generator
     {
-        yield 'object' => [new stdClass()];
+        yield 'empty key' => ['', 'foo'];
 
-        yield 'array' => [[]];
-
-        yield 'bool' => [true];
-
-        yield 'empty string' => [''];
-    }
-
-    public function testNoneStringKeyForGetter(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Unsupported identifier type "stdClass"');
-
-        (new DeferredSourceDefinitionsMutable(static fn () => []))[new stdClass()];
-    }
-
-    public function testNoneStringKeyForExister(): void
-    {
-        $s = new DeferredSourceDefinitionsMutable(static fn () => []);
-
-        self::assertFalse(isset($s[new stdClass()]));
-    }
-
-    public function testNoneStringKeyForUnset(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable');
-
-        $s = new DeferredSourceDefinitionsMutable(static fn () => []);
-        unset($s[new stdClass()]);
-    }
-
-    public function testUnset(): void
-    {
-        $this->expectException(SourceDefinitionsMutableExceptionInterface::class);
-        $this->expectExceptionMessage('Definitions in the source are non-removable');
-
-        $src = static fn (): iterable => ['service.bar' => 'Service bar'];
-
-        $s = new DeferredSourceDefinitionsMutable($src);
-        unset($s['service.bar']);
+        yield 'number and value none implement DiDefinitionIdentifierInterface' => [10, 'foo'];
     }
 
     public function testRemovedDefinitionIds(): void
@@ -202,7 +153,7 @@ class SourceDefinitionsMutableTest extends TestCase
         self::assertSame(['service.bar', 'service.baz'], array_keys([...$s->getIterator()]));
 
         // set service id and remove if exist in `removedDefinitionIds`
-        $s['service.foo'] = 'Service foo';
+        $s->set('service.foo', 'Service foo');
         self::assertFalse($s->isRemovedDefinition('service.foo'));
     }
 
@@ -226,9 +177,9 @@ class SourceDefinitionsMutableTest extends TestCase
             static fn () => yield new DiDefinitionRuntime('service.foo')
         );
 
-        $s['service.foo'] = $instance = (object) ['bar' => 'Service bar'];
+        $s->set('service.foo', $instance = (object) ['bar' => 'Service bar']);
 
-        self::assertSame($instance, $s['service.foo']->getDefinition());
+        self::assertSame($instance, $s->get('service.foo')->getDefinition());
     }
 
     public function testReplaceRuntimeDefinitionFail(): void
@@ -240,7 +191,7 @@ class SourceDefinitionsMutableTest extends TestCase
             static fn () => yield new DiDefinitionRuntime('service.foo')
         );
 
-        $s['service.foo'] = ['bar' => 'Service bar'];
+        $s->set('service.foo', ['bar' => 'Service bar']);
     }
 
     public function testUseStaticFabricAsSource(): void
@@ -250,10 +201,18 @@ class SourceDefinitionsMutableTest extends TestCase
             '\Tests\SourceDefinitionsMutable\SourceDefinitions::removed'
         );
 
-        self::assertFalse(isset($s['baz']));
+        self::assertFalse($s->has('baz'));
         self::assertTrue($s->isRemovedDefinition('baz'));
 
-        self::assertTrue(isset($s['foo'], $s['qux']));
+        self::assertTrue($s->has('foo'));
+        self::assertTrue($s->has('qux'));
+    }
+
+    public function testHasEmptyString(): void
+    {
+        $s = new DeferredSourceDefinitionsMutable(static fn () => []);
+
+        self::assertFalse($s->has(''));
     }
 }
 


### PR DESCRIPTION
Resolve #548 

* Implement new methods in `AbstractSourceDefinitionsMutable` and removes unsupported methods.

* `DeferredSourceDefinitionsMutable` - use new methods from `AbstractSourceDefinitionsMutable`.

* `ImmediateSourceDefinitionsMutable` - use new methods from `AbstractSourceDefinitionsMutable`.

* `DiContainer` use new methods from `SourceDefinitionsMutableInterface`.

* Update tests.