### PR TITLE
Uses tags for `DiDefinitionRuntime`.

### DIFF
--- a/docs/10-runtime-definition.md
+++ b/docs/10-runtime-definition.md
@@ -17,14 +17,28 @@
 Хелпер функция для конфигурационных файлов.
 
 ```php
-use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use function \Kaspi\DiContainer\diRuntime;
 
-diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoArgumentsInterface
+diRuntime(
+    string $containerIdentifier,
+    ?string $message = null,
+    ?string $classDefinition = null
+): DiDefinitionTagArgumentInterface
 ```
 Параметры:
 - `$containerIdentifier` – идентификатора контейнера реализующий сервис, который будет добавлен позже.
 - `$message` – дополнительное информационное сообщение при ошибке.
+- `$classDefinition` – применяется для точного указания PHP класса в определении если необходимо [получать ключ элемента](05-tags.md#ключ-из-метаданных-тега-через-метод-класса) в тегированной коллекции через метод PHP класса или [получать приоритет элемента в тегированной коллекции](05-tags.md#prioritymethod-и-prioritydefaultmethod-для-приоритизации-в-коллекции) через метод PHP класса.
+
+> [!IMPORTANT]
+> Функция `diRuntime` возвращает объект реализующий интерфейс
+> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface`.
+>
+> Интерфейс представляет методы:
+>   - `bindTag` - добавляет тег с мета-данными для определения
+>
+> [Пример использования тегов](#пример-тегирования-runtime-definition).
 
 > [!WARNING]
 > Хелпер функция не может быть применена к параметрам метода класса или callable выражения.
@@ -167,6 +181,60 @@ class Kernel {
         // Инициализация класс Bar
         $bar = new Bar(...\do_calcualte_bar_params());
         $this->container->set('services.bar', $bar);
+    }
+}
+```
+## Пример тегирования Runtime definition.
+Для «runtime definition» можно определять теги.
+
+### Пример тегирования через хелпер функцию diRuntime в конфигурационных файлах.
+```php
+// /app/config/runtime_definitions.php
+use App\Core\Kernel;
+use App\RuntimeServices\Foo;
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use function Kaspi\DiContainer\diRuntime;
+
+return static function (DefinitionsConfiguratorInterface $configurator) {
+    yield diRuntime(Kernel::class)
+        ->bindTag('tags.core');
+
+    yield diRuntime('services.foo', classDefinition: Foo::class)
+        ->bindTag(
+            'tags.core_services',
+            // 🚩 ключ коллекции из метода класса Foo::getKey()
+            options: ['key' => 'self::getKey'],
+        );
+};
+```
+### Пример тегирования через PHP атрибуты.
+
+```php
+namespace Core;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[DiRuntime]
+#[Tag('tags.core')]
+class Kernel {
+    // ...
+}
+```
+```php
+// /app/src/RuntimeServices/Foo.php
+namespace App\RuntimeServices;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[DiRuntime(containerIdentifier: 'services.foo')]
+#[Tag('tags.core_services', options: ['key' => 'self::getKey'])]
+final class Foo {
+    // ...
+    public static function getKey(): string
+    {
+        return 'runtime_definition.foo';
     }
 }
 ```

--- a/src/DiContainer/Attributes/DiRuntime.php
+++ b/src/DiContainer/Attributes/DiRuntime.php
@@ -11,7 +11,6 @@ final class DiRuntime
 {
     /**
      * @param class-string|string $containerIdentifier
-     * @param null|class-string   $classDefinition
      */
-    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null, public readonly ?string $classDefinition = null) {}
+    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null) {}
 }

--- a/src/DiContainer/Attributes/DiRuntime.php
+++ b/src/DiContainer/Attributes/DiRuntime.php
@@ -9,5 +9,9 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class DiRuntime
 {
-    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null) {}
+    /**
+     * @param class-string|string $containerIdentifier
+     * @param null|class-string   $classDefinition
+     */
+    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null, public readonly ?string $classDefinition = null) {}
 }

--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -630,7 +630,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
                     );
                 }
 
-                $diRuntimeServices[$containerIdentifier] = new DiDefinitionRuntime($containerIdentifier, $diRuntimeAttr->message, $diRuntimeAttr->classDefinition);
+                $diRuntimeServices[$containerIdentifier] = new DiDefinitionRuntime($containerIdentifier, $diRuntimeAttr->message, $reflectionClass->name);
             }
 
             return $diRuntimeServices;

--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -630,7 +630,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
                     );
                 }
 
-                $diRuntimeServices[$containerIdentifier] = new DiDefinitionRuntime($containerIdentifier, $diRuntimeAttr->message);
+                $diRuntimeServices[$containerIdentifier] = new DiDefinitionRuntime($containerIdentifier, $diRuntimeAttr->message, $diRuntimeAttr->classDefinition);
             }
 
             return $diRuntimeServices;

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -381,7 +381,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             if (($diRuntimes = AttributeReader::getDiRuntimeAttribute($reflectionClass))->valid()) {
                 foreach ($diRuntimes as $diRuntime) {
                     if ($diRuntime->containerIdentifier === $reflectionClass->name) {
-                        return $this->diResolvedDefinition[$id] = new DiDefinitionRuntime($diRuntime->containerIdentifier, $diRuntime->message, $reflectionClass->name);
+                        return $this->diResolvedDefinition[$id] = new DiDefinitionRuntime($diRuntime->containerIdentifier, $diRuntime->message);
                     }
                 }
             }

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -28,6 +28,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSingletonInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
@@ -230,11 +231,11 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
             $hasTagAsInterface = false;
 
-            if ($definition instanceof DiDefinitionAutowireInterface) {
+            if ($definition instanceof DiTaggedObjectDefinitionInterface) {
                 $tagIsInterface ??= interface_exists($tag);
                 // Pass container with configuration for determinate using php attribute or not.
                 $definition->setContainer($this);
-                $hasTagAsInterface = $tagIsInterface && $definition->getDefinition()->implementsInterface($tag);
+                $hasTagAsInterface = $tagIsInterface && $definition->isImplementInterface($tag);
             }
 
             if ($hasTagAsInterface || (true !== $tagIsInterface && $definition->hasTag($tag))) {

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -381,7 +381,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             if (($diRuntimes = AttributeReader::getDiRuntimeAttribute($reflectionClass))->valid()) {
                 foreach ($diRuntimes as $diRuntime) {
                     if ($diRuntime->containerIdentifier === $reflectionClass->name) {
-                        return $this->diResolvedDefinition[$id] = new DiDefinitionRuntime($diRuntime->containerIdentifier, $diRuntime->message);
+                        return $this->diResolvedDefinition[$id] = new DiDefinitionRuntime($diRuntime->containerIdentifier, $diRuntime->message, $reflectionClass->name);
                     }
                 }
             }

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\DiDefinition;
 
-use InvalidArgumentException;
 use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\Attributes\Setup;
-use Kaspi\DiContainer\Attributes\Tag;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\Enum\SetupConfigureMethod;
-use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
@@ -21,43 +18,33 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Traits\BindArgumentsTrait;
-use Kaspi\DiContainer\Traits\TagsTrait;
+use Kaspi\DiContainer\Traits\TagsOnObjectDefinitionTrait;
 use ReflectionClass;
 use ReflectionException;
 
 use function call_user_func_array;
 use function get_class;
 use function get_debug_type;
-use function is_callable;
-use function is_int;
-use function is_null;
 use function is_object;
 use function is_string;
 use function sprintf;
-use function trim;
-use function var_export;
 
 /**
  * @phpstan-import-type DiDefinitionType from DiDefinitionArgumentsInterface
- * @phpstan-import-type Tags from DiTaggedDefinitionInterface
- * @phpstan-import-type TagOptions from DiDefinitionTagArgumentInterface
  *
  * @phpstan-type SetupConfigureArgumentsType array<non-empty-string|non-negative-int, DiDefinitionType|mixed>
  * @phpstan-type SetupConfigureItem array{0: SetupConfigureMethod, 1: SetupConfigureArgumentsType}
  */
-final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDefinitionSetupAutowireInterface, DiDefinitionIdentifierInterface, DiDefinitionTagArgumentInterface, DiTaggedDefinitionInterface
+final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDefinitionSetupAutowireInterface, DiDefinitionIdentifierInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface
 {
     use BindArgumentsTrait {
         bindArguments as private bindArgumentsInternal;
     }
-    use TagsTrait {
-        getTags as public getBoundTags;
-        hasTag as private hasTagInternal;
-        geTagPriority as private geTagPriorityInternal;
-    }
+
+    use TagsOnObjectDefinitionTrait;
 
     private ReflectionClass $reflectionClass;
 
@@ -67,13 +54,6 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
      * @var list<array{0: SetupConfigureMethod, 1: ArgumentBuilderInterface}>
      */
     private array $setupArgBuilders;
-
-    /**
-     * Tags from php attributes on class.
-     *
-     * @var array<non-empty-string, TagOptions>
-     */
-    private array $tagsByAttribute;
 
     /**
      * Methods for setup service by PHP definition via setters (mutable or immutable).
@@ -88,8 +68,6 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
      * @var array<non-empty-string, list<SetupConfigureItem>>
      */
     private array $setupByAttributes;
-
-    private DiContainerInterface $container;
 
     /**
      * @param class-string|ReflectionClass $definition
@@ -131,13 +109,6 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
     public function isSingleton(): ?bool
     {
         return $this->isSingleton;
-    }
-
-    public function setContainer(DiContainerInterface $container): static
-    {
-        $this->container = $container;
-
-        return $this;
     }
 
     public function exposeArgumentBuilder(DiContainerInterface $container): ?ArgumentBuilderInterface
@@ -227,7 +198,7 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
     }
 
     /**
-     * @return class-string|non-empty-string
+     * @return class-string
      */
     public function getIdentifier(): string
     {
@@ -236,145 +207,14 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
             : $this->reflectionClass->getName();
     }
 
-    /**
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function getTags(): array
+    public function isImplementInterface(string $interface): bool
     {
-        if (!$this->getContainer()->getConfig()->isUseAttribute()) {
-            return $this->getBoundTags();
-        }
-
-        try {
-            // 🚩 PHP attributes have higher priority than PHP definitions (see documentation.)
-            return $this->getTagsByAttribute() + $this->getBoundTags();
-        } catch (DiDefinitionExceptionInterface $e) {
-            throw new DiDefinitionException(
-                message: sprintf('Cannot get tags on class "%s".', $this->getIdentifier()),
-                previous: $e,
-            );
-        }
+        return $this->getDefinition()->implementsInterface($interface);
     }
 
-    /**
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function hasTag(string $name): bool
+    public function getDefinitionIdentifier(): string
     {
-        try {
-            return isset($this->getTags()[$name]);
-        } catch (DiDefinitionExceptionInterface $e) {
-            throw new DiDefinitionException(
-                message: sprintf('Cannot check exist tag "%s" on class "%s".', $name, $this->getIdentifier()),
-                previous: $e,
-            );
-        }
-    }
-
-    /**
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function getTag(string $name): ?array
-    {
-        try {
-            return $this->getTags()[$name] ?? null;
-        } catch (DiDefinitionExceptionInterface $e) {
-            throw new DiDefinitionException(
-                message: sprintf('Cannot get tag "%s" on class "%s".', $name, $this->getIdentifier()),
-                previous: $e,
-            );
-        }
-    }
-
-    /**
-     * @param non-empty-string $name
-     * @param TagOptions       $operationOptions
-     *
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function geTagPriority(string $name, array $operationOptions = []): int|string|null
-    {
-        if (null !== ($priority = $this->geTagPriorityInternal($name, $operationOptions))) {
-            return $priority;
-        }
-
-        $tagOptions = $operationOptions + ($this->getTag($name) ?? []);
-
-        if (isset($tagOptions['priority.method'])) {
-            $method = $tagOptions['priority.method'];
-
-            if (!is_string($method) || '' === trim($method)) {
-                $wherePriorityMethod = isset($this->getBoundTags()[$name]['priority.method'])
-                    ? 'value with key "priority.method" in the $options parameter in '.DiDefinitionTagArgumentInterface::class.'::bindTag()'
-                    : 'the $priorityMethod parameter or the value with key "priority.method" in the $options parameter in the php attribute #[Tag]';
-
-                throw new DiDefinitionException(
-                    sprintf('Cannot get tag priority for tag "%s" via method in class %s. The name of the priority method is specified by %s. Priority method must be present none-empty string. Got: %s', $name, $this->getIdentifier(), $wherePriorityMethod, var_export($method, true))
-                );
-            }
-
-            try {
-                return $this->getTagPriorityFromMethod($method, $name, $tagOptions);
-            } catch (AutowireException|InvalidArgumentException $e) {
-                throw new DiDefinitionException(
-                    message: sprintf('Cannot get tag priority for tag "%s" via method %s::%s(). Caused by: %s', $name, $this->getIdentifier(), $method, $e->getMessage()),
-                    previous: $e
-                );
-            }
-        }
-
-        // Option (meta-key) only from $operationOptions. It uses through DiDefinitionTaggedAs.
-        $priorityDefaultMethod = ($operationOptions['priority.default_method'] ?? null);
-
-        if (!is_string($priorityDefaultMethod)) {
-            return null;
-        }
-
-        try {
-            return $this->getTagPriorityFromMethod($priorityDefaultMethod, $name, $tagOptions);
-        } catch (InvalidArgumentException) {
-            return null;
-        } catch (AutowireException $e) {
-            throw new DiDefinitionException(
-                message: sprintf('Cannot get tag priority for tag "%s" via default priority method %s::%s(). Caused by: %s', $name, $this->getIdentifier(), $priorityDefaultMethod, $e->getMessage()),
-                previous: $e
-            );
-        }
-    }
-
-    /**
-     * @return array<non-empty-string, TagOptions>
-     *
-     * @throws DiDefinitionExceptionInterface
-     */
-    public function getTagsByAttribute(): array
-    {
-        if (isset($this->tagsByAttribute)) {
-            return $this->tagsByAttribute;
-        }
-
-        $this->tagsByAttribute = [];
-
-        try {
-            $tagAttributes = AttributeReader::getTagAttribute($this->getDefinition());
-        } catch (DiDefinitionExceptionInterface $e) {
-            throw new DiDefinitionException(
-                message: sprintf('Cannot read php attribute #[%s] on class "%s".', Tag::class, $this->getIdentifier()),
-                previous: $e,
-            );
-        }
-
-        foreach ($tagAttributes as $tagAttribute) {
-            $priorityMethod = null !== $tagAttribute->priorityMethod
-                ? ['priority.method' => $tagAttribute->priorityMethod]
-                : [];
-            $this->tagsByAttribute[$tagAttribute->name] = self::transformTagOptions(
-                $priorityMethod + $tagAttribute->options,
-                $tagAttribute->priority
-            );
-        }
-
-        return $this->tagsByAttribute;
+        return $this->getIdentifier();
     }
 
     /**
@@ -401,17 +241,6 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
         return $this->setupByAttributes + $this->setup;
     }
 
-    private function getContainer(): DiContainerInterface
-    {
-        if (!isset($this->container)) {
-            throw new DiDefinitionException(
-                sprintf('Need set container implementation. Use method %s::setContainer(). Definition identifier "%s".', __CLASS__, $this->getIdentifier())
-            );
-        }
-
-        return $this->container;
-    }
-
     /**
      * @throws DiDefinitionExceptionInterface
      */
@@ -420,29 +249,5 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
         if (!$this->getDefinition()->isInstantiable()) {
             throw new DiDefinitionException(sprintf('The "%s" class is not instantiable.', $this->getDefinition()->getName()));
         }
-    }
-
-    /**
-     * @param TagOptions $tagOptions
-     *
-     * @throws AutowireException|InvalidArgumentException
-     */
-    private function getTagPriorityFromMethod(string $method, string $tag, array $tagOptions): int|string|null
-    {
-        $callable = [$this->getIdentifier(), $method];
-
-        if (!is_callable($callable)) {
-            throw new InvalidArgumentException('Method must be declared with public and static modifiers.');
-        }
-
-        $priority = $callable($tag, $tagOptions);
-
-        if (is_int($priority) || is_string($priority) || is_null($priority)) {
-            return $priority;
-        }
-
-        throw new AutowireException(
-            sprintf('Method must return type "int|string|null" but return type "%s".', get_debug_type($priority))
-        );
     }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -8,25 +8,31 @@ use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
-use Kaspi\DiContainer\Traits\TagsTrait;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
+use Kaspi\DiContainer\Traits\TagsOnObjectDefinitionTrait;
+use ReflectionClass;
+use ReflectionException;
 
 use function rtrim;
 use function sprintf;
 use function var_export;
 
-final class DiDefinitionRuntime implements DiDefinitionTagArgumentInterface, DiTaggedDefinitionInterface, DiDefinitionRuntimeInterface
+final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface
 {
-    use TagsTrait;
+    use TagsOnObjectDefinitionTrait;
 
     private object $definition;
 
+    private ReflectionClass $classDefinitionReflection;
+
     /**
      * @param class-string|non-empty-string $containerIdentifier
+     * @param null|class-string             $classDefinition
      */
     public function __construct(
         private readonly string $containerIdentifier,
         private readonly ?string $message = null,
+        private readonly ?string $classDefinition = null,
     ) {}
 
     public function getIdentifier(): string
@@ -61,6 +67,25 @@ final class DiDefinitionRuntime implements DiDefinitionTagArgumentInterface, DiT
 
     public function setDefinition(object $definition): void
     {
-        $this->definition = $definition;
+        $this->definition ??= $definition;
+    }
+
+    public function isImplementInterface(string $interface): bool
+    {
+        try {
+            $this->classDefinitionReflection ??= new ReflectionClass($this->getDefinitionIdentifier());
+        } catch (ReflectionException $e) {
+            throw new DiDefinitionException(
+                sprintf('You should to be defined a php class through the parameters $containerIdentifier or $classDefinition. Current values: $containerIdentifier %s, $classDefinition %s', var_export($this->containerIdentifier, true), var_export($this->classDefinition, true)),
+                previous: $e,
+            );
+        }
+
+        return $this->classDefinitionReflection->implementsInterface($interface);
+    }
+
+    public function getDefinitionIdentifier(): string
+    {
+        return $this->classDefinition ?? $this->containerIdentifier; // @phpstan-ignore return.type
     }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -6,15 +6,19 @@ namespace Kaspi\DiContainer\DiDefinition;
 
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Traits\TagsTrait;
 
 use function rtrim;
 use function sprintf;
 use function var_export;
 
-final class DiDefinitionRuntime implements DiDefinitionNoArgumentsInterface, DiDefinitionRuntimeInterface
+final class DiDefinitionRuntime implements DiDefinitionTagArgumentInterface, DiTaggedDefinitionInterface, DiDefinitionRuntimeInterface
 {
+    use TagsTrait;
+
     private object $definition;
 
     /**

--- a/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionTaggedAs.php
@@ -9,10 +9,10 @@ use InvalidArgumentException;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\LazyDefinitionIterator;
 use SplPriorityQueue;
@@ -37,7 +37,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
      */
     private array $flippedContainerIdExclude;
 
-    private ?DiDefinitionAutowireInterface $callingByDefinitionAutowire = null;
+    private ?DiTaggedObjectDefinitionInterface $callingByDefinition = null;
 
     /**
      * @param non-empty-string       $tag
@@ -84,8 +84,8 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
      */
     public function exposeContainerIdentifiers(DiContainerInterface $container, mixed $context = null): iterable
     {
-        if ($context instanceof DiDefinitionAutowireInterface) {
-            $this->callingByDefinitionAutowire = $context;
+        if ($context instanceof DiTaggedObjectDefinitionInterface) {
+            $this->callingByDefinition = $context;
         }
 
         $mapKeyToContainerIdentifier = [];
@@ -105,9 +105,9 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
     }
 
     /**
-     * @param iterable<non-empty-string, (DiDefinitionAutowireInterface&DiTaggedDefinitionInterface)|DiTaggedDefinitionInterface> $definitions
+     * @param iterable<non-empty-string, DiTaggedDefinitionInterface|DiTaggedObjectDefinitionInterface> $definitions
      *
-     * @return Generator<array{0: non-empty-string, 1: (DiDefinitionAutowireInterface&DiTaggedDefinitionInterface)|DiTaggedDefinitionInterface}>
+     * @return Generator<array{0: non-empty-string, 1: DiTaggedDefinitionInterface|DiTaggedObjectDefinitionInterface}>
      *
      * @throws DiDefinitionExceptionInterface
      */
@@ -123,13 +123,13 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
 
         foreach ($definitions as $containerIdentifier => $definition) {
             if (isset($this->flippedContainerIdExclude[$containerIdentifier])
-                || ($this->selfExclude && $containerIdentifier === $this->callingByDefinitionAutowire?->getDefinition()->getName())) {
+                || ($this->selfExclude && $containerIdentifier === $this->callingByDefinition?->getDefinitionIdentifier())) {
                 continue;
             }
 
             $operationOptions = [];
 
-            if ($definition instanceof DiDefinitionAutowireInterface) {
+            if ($definition instanceof DiTaggedObjectDefinitionInterface) {
                 $operationOptions['priority.default_method'] = $this->priorityDefaultMethod;
             }
 
@@ -137,21 +137,20 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
             $taggedServices->insert([$containerIdentifier, $definition], $definition->geTagPriority($this->tag, $operationOptions));
         }
 
-        /** @var array{0: non-empty-string, 1: (DiDefinitionAutowireInterface&DiTaggedDefinitionInterface)|DiTaggedDefinitionInterface} $item */
+        /** @var array{0: non-empty-string, 1: DiTaggedDefinitionInterface|DiTaggedObjectDefinitionInterface} $item */
         foreach ($taggedServices as $item) {
             yield $item;
         }
     }
 
     /**
-     * @param non-empty-string                                                                        $identifier
-     * @param (DiDefinitionAutowireInterface&DiTaggedDefinitionInterface)|DiTaggedDefinitionInterface $taggedAs
+     * @param non-empty-string $identifier
      *
      * @return non-empty-string
      *
      * @throws DiDefinitionExceptionInterface
      */
-    private function getTagKeyFromTagOptionsOrFromClassMethod(string $identifier, DiDefinitionAutowireInterface|DiTaggedDefinitionInterface $taggedAs): string
+    private function getTagKeyFromTagOptionsOrFromClassMethod(string $identifier, DiTaggedDefinitionInterface|DiTaggedObjectDefinitionInterface $taggedAs): string
     {
         if (null !== $this->key) {
             if (!isset($this->keyChecked)) {
@@ -173,7 +172,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                     );
                 }
 
-                if (!$taggedAs instanceof DiDefinitionAutowireInterface) {
+                if (!$taggedAs instanceof DiTaggedObjectDefinitionInterface) {
                     return $optionKey;
                 }
 
@@ -184,27 +183,27 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
                 try {
                     $method = explode('::', $optionKey)[1];
 
-                    return $this->getTagKeyFromClassMethod($taggedAs->getIdentifier(), $method, $taggedAs);
+                    return $this->getTagKeyFromClassMethod($taggedAs->getDefinitionIdentifier(), $method, $taggedAs);
                 } catch (AutowireException|InvalidArgumentException $e) {
                     throw new DiDefinitionException(
-                        message: sprintf('Cannot get key for tag "%s" via method %s::%s(). Caused by: %s', $this->tag, $taggedAs->getIdentifier(), $method, $e->getMessage()),
+                        message: sprintf('Cannot get key for tag "%s" via method %s::%s(). Caused by: %s', $this->tag, $taggedAs->getDefinitionIdentifier(), $method, $e->getMessage()),
                         previous: $e
                     );
                 }
             }
         }
 
-        if (null === $this->keyDefaultMethod || !($taggedAs instanceof DiDefinitionAutowireInterface)) {
+        if (null === $this->keyDefaultMethod || !($taggedAs instanceof DiTaggedObjectDefinitionInterface)) {
             return $identifier;
         }
 
         try {
-            return $this->getTagKeyFromClassMethod($taggedAs->getIdentifier(), $this->keyDefaultMethod, $taggedAs);
+            return $this->getTagKeyFromClassMethod($taggedAs->getDefinitionIdentifier(), $this->keyDefaultMethod, $taggedAs);
         } catch (InvalidArgumentException) {
             return $identifier;
         } catch (AutowireException $e) {
             throw new DiDefinitionException(
-                message: sprintf('Cannot get key for tag "%s" via default method %s::%s(). Caused by: %s', $this->tag, $taggedAs->getIdentifier(), $this->keyDefaultMethod, $e->getMessage()),
+                message: sprintf('Cannot get key for tag "%s" via default method %s::%s(). Caused by: %s', $this->tag, $taggedAs->getDefinitionIdentifier(), $this->keyDefaultMethod, $e->getMessage()),
                 previous: $e
             );
         }
@@ -215,7 +214,7 @@ final class DiDefinitionTaggedAs implements DiDefinitionTaggedAsInterface, DiDef
      *
      * @throws AutowireException|InvalidArgumentException
      */
-    private function getTagKeyFromClassMethod(string $class, string $method, DiTaggedDefinitionInterface $taggedAs): string
+    private function getTagKeyFromClassMethod(string $class, string $method, DiTaggedObjectDefinitionInterface $taggedAs): string
     {
         $callable = [$class, $method];
 

--- a/src/DiContainer/Interfaces/DiContainerInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerInterface.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSingletonInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -43,7 +44,7 @@ interface DiContainerInterface extends ContainerInterface
     /**
      * @param non-empty-string $tag
      *
-     * @return iterable<non-empty-string, (DiDefinitionAutowireInterface&DiTaggedDefinitionInterface)|DiTaggedDefinitionInterface>
+     * @return iterable<non-empty-string, DiTaggedDefinitionInterface|DiTaggedObjectDefinitionInterface>
      *
      * @throws DiDefinitionExceptionInterface
      */

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionAutowireInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionAutowireInterface.php
@@ -20,8 +20,6 @@ interface DiDefinitionAutowireInterface extends DiDefinitionSingletonInterface
      */
     public function getDefinition(): ReflectionClass;
 
-    public function setContainer(DiContainerInterface $container): static;
-
     /**
      * @return class-string|non-empty-string
      */

--- a/src/DiContainer/Interfaces/DiDefinition/DiTaggedObjectDefinitionInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiTaggedObjectDefinitionInterface.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+
+/**
+ * @phpstan-import-type Tags from DiTaggedDefinitionInterface
+ * @phpstan-import-type TagOptions from DiDefinitionTagArgumentInterface
+ *
+ * Tagged php class.
+ */
+interface DiTaggedObjectDefinitionInterface extends DiTaggedDefinitionInterface
+{
+    /**
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function getTags(): array;
+
+    /**
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function hasTag(string $name): bool;
+
+    /**
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function getTag(string $name): ?array;
+
+    /**
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function geTagPriority(string $name, array $operationOptions = []): int|string|null;
+
+    /**
+     * @return class-string
+     */
+    public function getDefinitionIdentifier(): string;
+
+    public function setContainer(DiContainerInterface $container): static;
+
+    /**
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function isImplementInterface(string $interface): bool;
+
+    /**
+     * Gets bound tags without bound tags via php attributes.
+     *
+     * @see DiDefinitionTagArgumentInterface::bindTag()
+     *
+     * @return Tags
+     */
+    public function getBoundTags(): array;
+
+    /**
+     * Gets bound tags via php attributes only.
+     *
+     * @return array<non-empty-string, TagOptions>
+     *
+     * @throws DiDefinitionExceptionInterface
+     */
+    public function getTagsByAttribute(): array;
+}

--- a/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
+++ b/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Traits;
+
+use InvalidArgumentException;
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\Tag;
+use Kaspi\DiContainer\Exception\AutowireException;
+use Kaspi\DiContainer\Exception\DiDefinitionException;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+
+use function get_debug_type;
+use function is_callable;
+use function is_int;
+use function is_null;
+use function is_string;
+use function sprintf;
+use function trim;
+use function var_export;
+
+/**
+ * @phpstan-import-type Tags from DiTaggedDefinitionInterface
+ * @phpstan-import-type TagOptions from DiDefinitionTagArgumentInterface
+ */
+trait TagsOnObjectDefinitionTrait
+{
+    use TagsTrait {
+        getTags as public getBoundTags;
+        hasTag as private hasTagInternal;
+        geTagPriority as private geTagPriorityInternal;
+    }
+
+    private DiContainerInterface $container;
+
+    /**
+     * Tags from php attributes on class.
+     *
+     * @var array<non-empty-string, TagOptions>
+     */
+    private array $tagsByAttribute;
+
+    abstract public function getDefinitionIdentifier(): string;
+
+    public function setContainer(DiContainerInterface $container): static
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    public function getTags(): array
+    {
+        if (!$this->getContainer()->getConfig()->isUseAttribute()) {
+            return $this->getBoundTags();
+        }
+
+        try {
+            // 🚩 PHP attributes have higher priority than PHP definitions (see documentation.)
+            return $this->getTagsByAttribute() + $this->getBoundTags();
+        } catch (DiDefinitionExceptionInterface $e) {
+            throw new DiDefinitionException(
+                message: sprintf('Cannot get tags on class "%s".', $this->getDefinitionIdentifier()),
+                previous: $e,
+            );
+        }
+    }
+
+    public function hasTag(string $name): bool
+    {
+        try {
+            return isset($this->getTags()[$name]);
+        } catch (DiDefinitionExceptionInterface $e) {
+            throw new DiDefinitionException(
+                message: sprintf('Cannot check exist tag "%s" on class "%s".', $name, $this->getDefinitionIdentifier()),
+                previous: $e,
+            );
+        }
+    }
+
+    public function getTag(string $name): ?array
+    {
+        try {
+            return $this->getTags()[$name] ?? null;
+        } catch (DiDefinitionExceptionInterface $e) {
+            throw new DiDefinitionException(
+                message: sprintf('Cannot get tag "%s" on class "%s".', $name, $this->getDefinitionIdentifier()),
+                previous: $e,
+            );
+        }
+    }
+
+    public function geTagPriority(string $name, array $operationOptions = []): int|string|null
+    {
+        if (null !== ($priority = $this->geTagPriorityInternal($name, $operationOptions))) {
+            return $priority;
+        }
+
+        $tagOptions = $operationOptions + ($this->getTag($name) ?? []);
+
+        if (isset($tagOptions['priority.method'])) {
+            $method = $tagOptions['priority.method'];
+
+            if (!is_string($method) || '' === trim($method)) {
+                $wherePriorityMethod = isset($this->getBoundTags()[$name]['priority.method'])
+                    ? 'value with key "priority.method" into the $options parameter pass via method '.DiDefinitionTagArgumentInterface::class.'::bindTag()'
+                    : 'the $priorityMethod parameter or the value with key "priority.method" into the $options parameter via the php attribute #[Tag]';
+
+                throw new DiDefinitionException(
+                    sprintf('Cannot get tag priority for tag "%s" via method in class %s. The name of the priority method is specified by %s. Priority method must be present none-empty string. Got: %s', $name, $this->getDefinitionIdentifier(), $wherePriorityMethod, var_export($method, true))
+                );
+            }
+
+            try {
+                return $this->getTagPriorityFromMethod($method, $name, $tagOptions);
+            } catch (AutowireException|InvalidArgumentException $e) {
+                throw new DiDefinitionException(
+                    message: sprintf('Cannot get tag priority for tag "%s" via method %s::%s(). Caused by: %s', $name, $this->getDefinitionIdentifier(), $method, $e->getMessage()),
+                    previous: $e
+                );
+            }
+        }
+
+        // Option (meta-key) only from $operationOptions. It uses through DiDefinitionTaggedAs.
+        $priorityDefaultMethod = ($operationOptions['priority.default_method'] ?? null);
+
+        if (!is_string($priorityDefaultMethod)) {
+            return null;
+        }
+
+        try {
+            return $this->getTagPriorityFromMethod($priorityDefaultMethod, $name, $tagOptions);
+        } catch (InvalidArgumentException) {
+            return null;
+        } catch (AutowireException $e) {
+            throw new DiDefinitionException(
+                message: sprintf('Cannot get tag priority for tag "%s" via default priority method %s::%s(). Caused by: %s', $name, $this->getDefinitionIdentifier(), $priorityDefaultMethod, $e->getMessage()),
+                previous: $e
+            );
+        }
+    }
+
+    public function getTagsByAttribute(): array
+    {
+        if (isset($this->tagsByAttribute)) {
+            return $this->tagsByAttribute;
+        }
+
+        $this->tagsByAttribute = [];
+
+        try {
+            $tagAttributes = AttributeReader::getTagAttribute($this->getDefinition());
+        } catch (DiDefinitionExceptionInterface $e) {
+            throw new DiDefinitionException(
+                message: sprintf('Cannot read php attribute #[%s] on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
+                previous: $e,
+            );
+        }
+
+        foreach ($tagAttributes as $tagAttribute) {
+            $priorityMethod = null !== $tagAttribute->priorityMethod
+                ? ['priority.method' => $tagAttribute->priorityMethod]
+                : [];
+            $this->tagsByAttribute[$tagAttribute->name] = self::transformTagOptions(
+                $priorityMethod + $tagAttribute->options,
+                $tagAttribute->priority
+            );
+        }
+
+        return $this->tagsByAttribute;
+    }
+
+    private function getContainer(): DiContainerInterface
+    {
+        if (!isset($this->container)) {
+            throw new DiDefinitionException(
+                sprintf('Need set container implementation. Use method %s::setContainer(). Definition identifier "%s".', self::class, $this->getDefinitionIdentifier())
+            );
+        }
+
+        return $this->container;
+    }
+
+    /**
+     * @param TagOptions $tagOptions
+     *
+     * @throws AutowireException|InvalidArgumentException
+     */
+    private function getTagPriorityFromMethod(string $method, string $tag, array $tagOptions): int|string|null
+    {
+        $callable = [$this->getDefinitionIdentifier(), $method];
+
+        if (!is_callable($callable)) {
+            throw new InvalidArgumentException('Method must be declared with public and static modifiers.');
+        }
+
+        $priority = $callable($tag, $tagOptions);
+
+        if (is_int($priority) || is_string($priority) || is_null($priority)) {
+            return $priority;
+        }
+
+        throw new AutowireException(
+            sprintf('Method must return type "int|string|null" but return type "%s".', get_debug_type($priority))
+        );
+    }
+}

--- a/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
+++ b/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
@@ -110,10 +110,10 @@ trait TagsOnObjectDefinitionTrait
             if (!is_string($method) || '' === trim($method)) {
                 $wherePriorityMethod = isset($this->getBoundTags()[$name]['priority.method'])
                     ? 'value with key "priority.method" into the $options parameter pass via method '.DiDefinitionTagArgumentInterface::class.'::bindTag()'
-                    : 'the $priorityMethod parameter or the value with key "priority.method" into the $options parameter via the php attribute #[Tag]';
+                    : 'the parameter $priorityMethod or the value with key "priority.method" into the $options parameter via the php attribute '.Tag::class;
 
                 throw new DiDefinitionException(
-                    sprintf('Cannot get tag priority for tag "%s" via method in class %s. The name of the priority method is specified by %s. Priority method must be present none-empty string. Got: %s', $name, $this->getDefinitionIdentifier(), $wherePriorityMethod, var_export($method, true))
+                    sprintf('Cannot get priority for tag name "%s" on class %s. The name of the priority method is specified by %s. Priority method must be present none-empty string. Got: %s', $name, $this->getDefinitionIdentifier(), $wherePriorityMethod, var_export($method, true))
                 );
             }
 
@@ -121,7 +121,7 @@ trait TagsOnObjectDefinitionTrait
                 return $this->getTagPriorityFromMethod($method, $name, $tagOptions);
             } catch (AutowireException|InvalidArgumentException $e) {
                 throw new DiDefinitionException(
-                    message: sprintf('Cannot get tag priority for tag "%s" via method %s::%s(). Caused by: %s', $name, $this->getDefinitionIdentifier(), $method, $e->getMessage()),
+                    message: sprintf('Cannot get priority for tag name "%s" on %s. Caused by: %s', $name, $this->getDefinitionIdentifier(), $e->getMessage()),
                     previous: $e
                 );
             }
@@ -140,7 +140,7 @@ trait TagsOnObjectDefinitionTrait
             return null;
         } catch (AutowireException $e) {
             throw new DiDefinitionException(
-                message: sprintf('Cannot get tag priority for tag "%s" via default priority method %s::%s(). Caused by: %s', $name, $this->getDefinitionIdentifier(), $priorityDefaultMethod, $e->getMessage()),
+                message: sprintf('Cannot get priority for tag name "%s" on class %s. Caused by: %s', $name, $this->getDefinitionIdentifier(), $e->getMessage()),
                 previous: $e
             );
         }
@@ -158,7 +158,7 @@ trait TagsOnObjectDefinitionTrait
             $tagAttributes = AttributeReader::getTagAttribute(new ReflectionClass($this->getDefinitionIdentifier()));
         } catch (ReflectionException $e) {
             throw new DiDefinitionException(
-                message: sprintf('Cannot read php attribute #[%s] on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
+                message: sprintf('Cannot read php attribute "%s" on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
                 previous: $e,
             );
         }
@@ -197,7 +197,9 @@ trait TagsOnObjectDefinitionTrait
         $callable = [$this->getDefinitionIdentifier(), $method];
 
         if (!is_callable($callable)) {
-            throw new InvalidArgumentException('Method must be declared with public and static modifiers.');
+            throw new InvalidArgumentException(
+                sprintf('The method must be declared with public and static modifiers. Got callable expression [%s, %s].', var_export($callable[0], true), var_export($callable[1], true))
+            );
         }
 
         $priority = $callable($tag, $tagOptions);
@@ -207,7 +209,7 @@ trait TagsOnObjectDefinitionTrait
         }
 
         throw new AutowireException(
-            sprintf('Method must return type "int|string|null" but return type "%s".', get_debug_type($priority))
+            sprintf('The return type must be of type "int|string|null", but the return type is "%s". Got callable expression [%s, %s].', get_debug_type($priority), var_export($callable[0], true), var_export($callable[1], true))
         );
     }
 }

--- a/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
+++ b/src/DiContainer/Traits/TagsOnObjectDefinitionTrait.php
@@ -13,6 +13,8 @@ use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use ReflectionClass;
+use ReflectionException;
 
 use function get_debug_type;
 use function is_callable;
@@ -153,8 +155,8 @@ trait TagsOnObjectDefinitionTrait
         $this->tagsByAttribute = [];
 
         try {
-            $tagAttributes = AttributeReader::getTagAttribute($this->getDefinition());
-        } catch (DiDefinitionExceptionInterface $e) {
+            $tagAttributes = AttributeReader::getTagAttribute(new ReflectionClass($this->getDefinitionIdentifier()));
+        } catch (ReflectionException $e) {
             throw new DiDefinitionException(
                 message: sprintf('Cannot read php attribute #[%s] on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
                 previous: $e,

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -106,10 +106,11 @@ if (!function_exists('Kaspi\DiContainer\diParameterRuntime')) { // @codeCoverage
 
 if (!function_exists('Kaspi\DiContainer\diRuntime')) { // @codeCoverageIgnore
     /**
-     * @param non-empty-string $containerIdentifier
+     * @param non-empty-string  $containerIdentifier
+     * @param null|class-string $classDefinition
      */
-    function diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionTagArgumentInterface
+    function diRuntime(string $containerIdentifier, ?string $message = null, ?string $classDefinition = null): DiDefinitionTagArgumentInterface
     {
-        return new DiDefinitionRuntime($containerIdentifier, $message);
+        return new DiDefinitionRuntime($containerIdentifier, $message, $classDefinition);
     }
 } // @codeCoverageIgnore

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -108,7 +108,7 @@ if (!function_exists('Kaspi\DiContainer\diRuntime')) { // @codeCoverageIgnore
     /**
      * @param non-empty-string $containerIdentifier
      */
-    function diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoArgumentsInterface
+    function diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionTagArgumentInterface
     {
         return new DiDefinitionRuntime($containerIdentifier, $message);
     }

--- a/tests/DefinitionsLoader/DefinitionsLoaderWithConfiguratorTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderWithConfiguratorTest.php
@@ -15,6 +15,7 @@ use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
 use Kaspi\DiContainer\FinderFullyQualifiedNameCollection;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
@@ -44,6 +45,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(AttributeReader::class)]
 #[CoversClass(Tag::class)]
 #[CoversClass(NotFoundDefinition::class)]
+#[CoversClass(TagsTrait::class)]
 class DefinitionsLoaderWithConfiguratorTest extends TestCase
 {
     public function testCircularLoadFromFile(): void

--- a/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
@@ -24,6 +24,8 @@ use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagTwoDefaul
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TagWrongPriorityMethod\Bar;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TagWrongPriorityMethod\Foo;
 
+use function preg_quote;
+
 /**
  * @internal
  */
@@ -175,7 +177,7 @@ class TagTest extends TestCase
     public function testGetPriorityMethodByPhpAttributeWithWrongType(string $class, string $tagName): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessage('the php attribute #[Tag]');
+        $this->expectExceptionMessageMatches('/^Cannot get priority for tag name "'.preg_quote($tagName).'" on class '.preg_quote($class).'.+Priority method must be present none-empty string/');
 
         $container = $this->createMock(DiContainerInterface::class);
         $container->method('getConfig')->willReturn(

--- a/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TagWrongPriorityMethod\Foo;
 #[CoversClass(DiContainerConfig::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionGet::class)]
+#[CoversClass(TagsTrait::class)]
 class TagTest extends TestCase
 {
     public function testTagsByBindTag(): void
@@ -173,7 +175,7 @@ class TagTest extends TestCase
     public function testGetPriorityMethodByPhpAttributeWithWrongType(string $class, string $tagName): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessage('in the php attribute #[Tag]');
+        $this->expectExceptionMessage('the php attribute #[Tag]');
 
         $container = $this->createMock(DiContainerInterface::class);
         $container->method('getConfig')->willReturn(

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
@@ -58,4 +58,34 @@ class DiDefinitionRuntimeTest extends TestCase
         self::assertSame($object, $d->getDefinition());
         self::assertSame($object, $d->resolve($this->createMock(DiContainerInterface::class)));
     }
+
+    #[TestWith(['foo', null, 'foo'])]
+    #[TestWith(['foo', Foo::class, 'Tests\DiDefinition\DiDefinitionRuntime\Foo'])]
+    public function testGetDefinitionIdentifier(string $containerIdentifier, ?string $classDefinition, string $expectDefinitionIdentifier): void
+    {
+        $d = new DiDefinitionRuntime($containerIdentifier, classDefinition: $classDefinition);
+
+        self::assertEquals($expectDefinitionIdentifier, $d->getDefinitionIdentifier());
+    }
+
+    public function testIsImplementInterfaceFail(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('You should to be defined a php class through the parameters $containerIdentifier or $classDefinition');
+
+        (new DiDefinitionRuntime('foo'))->isImplementInterface(FooInterface::class);
+    }
+
+    #[TestWith([Foo::class, null, FooInterface::class])]
+    #[TestWith(['service.foo', Foo::class, FooInterface::class])]
+    public function testIsImplementInterface(string $containerIdentifier, ?string $classDefinition, string $interface): void
+    {
+        $d = new DiDefinitionRuntime($containerIdentifier, classDefinition: $classDefinition);
+
+        self::assertEquals($containerIdentifier, $d->getIdentifier());
+        self::assertTrue($d->isImplementInterface($interface));
+    }
 }
+
+interface FooInterface {}
+final class Foo implements FooInterface {}

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsDefaultPriorityMethodTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsDefaultPriorityMethodTest.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -30,6 +31,7 @@ use function Kaspi\DiContainer\diAutowire;
 #[CoversClass(DiContainerConfig::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionTaggedAs::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsDefaultPriorityMethodTest extends TestCase
 {
     /**

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsDefaultPriorityMethodTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsDefaultPriorityMethodTest.php
@@ -21,6 +21,7 @@ use Tests\DiDefinition\DiDefinitionTaggedAs\Fixtures\DefaultPriorityMethodWrong\
 use Tests\DiDefinition\DiDefinitionTaggedAs\Fixtures\DefaultPriorityMethodWrong\Foo;
 
 use function Kaspi\DiContainer\diAutowire;
+use function preg_quote;
 
 /**
  * @internal
@@ -41,7 +42,7 @@ class TaggedAsDefaultPriorityMethodTest extends TestCase
     public function testGetDefaultPriorityMethodWrongWithPhpAttribute(string $tagName, array $definitions, string $method): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessageMatches('/via default priority method .+Baz::'.$method.'\(\).+Method must return type "int\|string\|null"/');
+        $this->expectExceptionMessageMatches('/Cannot get priority for tag name "'.preg_quote($tagName).'" on class.+Caused by: The return type must be of type "int\|string\|null"/');
 
         $container = $this->createMock(DiContainerInterface::class);
         $container->method('getConfig')->willReturn(
@@ -91,7 +92,7 @@ class TaggedAsDefaultPriorityMethodTest extends TestCase
     public function testGetDefaultPriorityMethodWrong(string $tagName, array $definitions, string $method): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessageMatches('/via default priority method .+Baz::'.$method.'()/');
+        $this->expectExceptionMessageMatches('/Cannot get priority for tag name "tags.baz" on class.+Caused by: The return type must be of type "int|string|null"/');
 
         // Php attribute disabled.
         $container = $this->createMock(DiContainerInterface::class);

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsExcludePhpAttributeTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsExcludePhpAttributeTest.php
@@ -11,6 +11,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\LazyDefinitionIterator;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ use function Kaspi\DiContainer\diAutowire;
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionTaggedAs::class)]
 #[CoversClass(LazyDefinitionIterator::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsExcludePhpAttributeTest extends TestCase
 {
     private ?DiContainerInterface $container = null;

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsExcludePhpDefinitionTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsExcludePhpDefinitionTest.php
@@ -9,6 +9,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\LazyDefinitionIterator;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +28,7 @@ use function Kaspi\DiContainer\diAutowire;
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionTaggedAs::class)]
 #[CoversClass(LazyDefinitionIterator::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsExcludePhpDefinitionTest extends TestCase
 {
     private ?DiContainerInterface $container = null;

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsImplementInterfaceTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsImplementInterfaceTest.php
@@ -18,6 +18,7 @@ use Kaspi\DiContainer\LazyDefinitionIterator;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +54,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsImplementInterfaceTest extends TestCase
 {
     public function testTaggedAsByAttributeImplementInterface(): void

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerCircularTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerCircularTest.php
@@ -21,6 +21,7 @@ use Kaspi\DiContainer\LazyDefinitionIterator;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -59,6 +60,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsThroughContainerCircularTest extends TestCase
 {
     public function testCircularTaggedAsByPhpDefinition(): void

--- a/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
+++ b/tests/DiDefinition/DiDefinitionTaggedAs/TaggedAsThroughContainerVariadicTest.php
@@ -19,6 +19,7 @@ use Kaspi\DiContainer\LazyDefinitionIterator;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +54,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(TagsTrait::class)]
 class TaggedAsThroughContainerVariadicTest extends TestCase
 {
     public function testVariadicByPhpDefinition(): void

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/Bar.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/Bar.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[Tag('foo.attr')]
+final class Bar {}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/Baz.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/Baz.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+use Kaspi\DiContainer\Attributes\TaggedAs;
+
+final class Baz
+{
+    public function __construct(
+        #[TaggedAs('foo.attr', priorityDefaultMethod: 'getPriority', keyDefaultMethod: 'getKey')]
+        public readonly iterable $tagged
+    ) {}
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/Foo.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/Foo.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[DiRuntime('service.foo')]
+#[Tag('foo.attr', priorityMethod: 'getPriority')]
+final class Foo implements FooInterface
+{
+    public static function getKey(): string
+    {
+        return 'tag_foo';
+    }
+
+    public static function getPriority(): int
+    {
+        return 200;
+    }
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/FooInterface.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/FooInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+interface FooInterface {}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/Qux.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/Qux.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+use Kaspi\DiContainer\Attributes\TaggedAs;
+
+final class Qux
+{
+    public function __construct(
+        #[TaggedAs(FooInterface::class)]
+        public readonly iterable $tagged
+    ) {}
+}

--- a/tests/Integration/DiDefinitionRuntime/Fixtures2/services.php
+++ b/tests/Integration/DiDefinitionRuntime/Fixtures2/services.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime\Fixtures2;
+
+use function Kaspi\DiContainer\diAutowire;
+use function Kaspi\DiContainer\diRuntime;
+use function Kaspi\DiContainer\diTaggedAs;
+
+return static function () {
+    yield diRuntime('service.foo', classDefinition: Foo::class)
+        ->bindTag('foo')
+    ;
+
+    yield diAutowire(Bar::class)
+        ->bindTag('foo')
+    ;
+
+    yield diAutowire(Baz::class)
+        ->bindArguments(
+            diTaggedAs('foo', priorityDefaultMethod: 'getPriority', keyDefaultMethod: 'getKey')
+        )
+    ;
+
+    yield diAutowire(Qux::class)
+        ->bindArguments(
+            tagged: diTaggedAs(FooInterface::class)
+        )
+    ;
+};

--- a/tests/Integration/DiDefinitionRuntime/TaggedAsRuntimeTest.php
+++ b/tests/Integration/DiDefinitionRuntime/TaggedAsRuntimeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\DiDefinitionRuntime;
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\DiContainerNullConfig;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Tests\Integration\DiDefinitionRuntime\Fixtures2\Baz;
+use Tests\Integration\DiDefinitionRuntime\Fixtures2\Qux;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+class TaggedAsRuntimeTest extends TestCase
+{
+    public function testTaggedAsRuntimeBindTag(): void
+    {
+        $c = (new DiContainerBuilder(
+            new DiContainerNullConfig()
+        ))
+            ->load(__DIR__.'/Fixtures2/services.php')
+            ->build()
+        ;
+
+        $baz = $c->get(Baz::class);
+
+        self::assertEquals('tag_foo', $baz->tagged->key());
+        $baz->tagged->next();
+        self::assertEquals('Tests\Integration\DiDefinitionRuntime\Fixtures2\Bar', $baz->tagged->key());
+        $baz->tagged->next();
+        self::assertFalse($baz->tagged->valid());
+
+        $qux = $c->get(Qux::class);
+        self::assertEquals('service.foo', $qux->tagged->key());
+        $qux->tagged->next();
+        self::assertFalse($qux->tagged->valid());
+
+        $baz->tagged->rewind();
+
+        $this->expectException(ContainerExceptionInterface::class);
+        $this->expectExceptionMessage('The runtime definition with container identifier \'service.foo\' cannot be resolved.');
+
+        $baz->tagged->current();
+    }
+
+    public function testTaggedAsRuntimeTagViaAttributes(): void
+    {
+        $c = (new DiContainerBuilder())
+            ->import('Tests\\', __DIR__.'/Fixtures2')
+            ->build()
+        ;
+
+        $baz = $c->get(Baz::class);
+
+        self::assertEquals('tag_foo', $baz->tagged->key());
+        $baz->tagged->next();
+        self::assertEquals('Tests\Integration\DiDefinitionRuntime\Fixtures2\Bar', $baz->tagged->key());
+        $baz->tagged->next();
+        self::assertFalse($baz->tagged->valid());
+
+        $qux = $c->get(Qux::class);
+        self::assertEquals('service.foo', $qux->tagged->key());
+        $qux->tagged->next();
+        self::assertFalse($qux->tagged->valid());
+
+        $qux->tagged->rewind();
+
+        $this->expectException(ContainerExceptionInterface::class);
+        $this->expectExceptionMessage('The runtime definition with container identifier \'service.foo\' cannot be resolved.');
+
+        $qux->tagged->current();
+    }
+}

--- a/tests/Tag/DefaultPriorityMethod/AsAttributeTest.php
+++ b/tests/Tag/DefaultPriorityMethod/AsAttributeTest.php
@@ -19,6 +19,7 @@ use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
 use Kaspi\DiContainer\Traits\BindArgumentsTrait;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +54,7 @@ use function Kaspi\DiContainer\diAutowire;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(TagsTrait::class)]
 class AsAttributeTest extends TestCase
 {
     public function testCollectionByInterface(): void

--- a/tests/TaggedAsKeys/KeyThroughContainerAsPhpDefinitionTest.php
+++ b/tests/TaggedAsKeys/KeyThroughContainerAsPhpDefinitionTest.php
@@ -20,6 +20,7 @@ use Kaspi\DiContainer\LazyDefinitionIterator;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -50,6 +51,7 @@ use function Kaspi\DiContainer\diTaggedAs;
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(TagsTrait::class)]
 class KeyThroughContainerAsPhpDefinitionTest extends TestCase
 {
     public function testNotLazyKeyAsString(): void


### PR DESCRIPTION
1. Resolve #525 


- [x] Реализация для `DiDefinitionRuntimeInterface` получение ключа коллекции из метода
- [x] Реализация для `DiDefinitionRuntimeInterface` получение приоритета в коллекции из метода
- [x] Реализация настройки тегов для класса настроенного как `DiDefinitionRuntime`
- [x] Обновить тесты с использованием tag
- [x] Обновить документацию