### PR TITLE
Php attribute `DiRuntime`

### DIFF
--- a/docs/10-runtime-definition.md
+++ b/docs/10-runtime-definition.md
@@ -4,13 +4,17 @@
 и может быть установлен только во время выполнения контейнера,
 но другие определения контейнера могут зависеть от такого сервиса (_класса_).
 
-Определения устанавливаемые во время выполнения контейнера, называются «Runtime definition».
-В файлах конфигураций используется «Runtime definition» чтобы контейнер знал о существовании такого определения
+**Определения устанавливаемые во время выполнения контейнера, называются «Runtime definition».**
+
+«Runtime definition» определения можно сконфигурировать через [файлы конфигураций](06-container-builder.md#загрузка-из-файлов-конфигураций)
+или указать через PHP атрибут на нужном классе.
+
+«Runtime definition» необходим чтобы контейнер знал о существовании такого определения
 во время [компиляции контейнера](06-container-builder.md#компиляция-контейнера)
 (_в противном случае другие определения контейнера, зависящие от «runtime definition», получат ошибку так как не найдут его в конфигурации_).
 
-## diRuntime
-Хелпер функция для конфигурации «Runtime definition» в списке зарегистрированных определений.
+## Хелпер функция diRuntime.
+Хелпер функция для конфигурационных файлов.
 
 ```php
 use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
@@ -19,7 +23,7 @@ use function \Kaspi\DiContainer\diRuntime;
 diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoArgumentsInterface
 ```
 Параметры:
-- `$containerIdentifier` – идентификатора контейнера (php класс, интерфейс или непустая строка) реализующий сервис, который будет добавлен позже.
+- `$containerIdentifier` – идентификатора контейнера реализующий сервис, который будет добавлен позже.
 - `$message` – дополнительное информационное сообщение при ошибке.
 
 > [!WARNING]
@@ -33,8 +37,32 @@ diRuntime(string $containerIdentifier, ?string $message = null): DiDefinitionNoA
 > Хелпер функция `diRuntime()` не создает конфигурацию экземпляра класса, а только предоставляет идентификатор контейнера.
 >
 
-## Пример использования.
-Конфигурация специализированных определений:
+> [!NOTE]
+> [Пример конфигурирования через хелпер функцию `diRuntime`](#пример-использования-хелпер-функции-diruntime-в-конфигурационных-файлах).
+
+
+## Атрибут DiRuntime.
+Применятся к классу для конфигурирования «Runtime definition» в контейнере.
+
+```php
+#[DiRuntime(string $containerIdentifier = '', ?string $message = null)]
+```
+Параметры:
+- `$containerIdentifier` – идентификатора контейнера реализующий сервис, который будет добавлен позже.
+- `$message` – дополнительное информационное сообщение при ошибке.
+
+> [!TIP]
+> Атрибут может быть применен к классу несколько раз с разными значениями параметра `$containerIdentifier`.
+> 
+
+> [!TIP]
+> Пустая строка в аргументе `$containerIdentifier` будет представлена как полное имя класса – **fully qualified class name** которая является идентификатором контейнера для этого php класса.
+
+> [!NOTE]
+> [Пример конфигурирования через PHP атрибут](#пример-использования-php-атрибута-diruntime-для-конфигурирования).
+
+## Пример использования хелпер функции `diRuntime` в конфигурационных файлах.
+
 ```php
 // /app/config/runtime_definitions.php
 use App\Core\Kernel;
@@ -85,6 +113,60 @@ class Kernel {
         
         $secureString = \calculate_secure_string();
         $this->container->set('secure_string', $secureString);
+    }
+}
+```
+## Пример использования PHP атрибута `DiRuntime` для конфигурирования.
+
+```php
+// /app/src/RuntimeServices/Foo.php
+namespace App\RuntimeServices;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+final class Foo {
+    // ...
+}
+```
+```php
+// /app/src/RuntimeServices/Bar.php
+namespace App\RuntimeServices;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime('services.bar')]
+final class Bar {
+    // ...
+}
+```
+Конфигурация контейнера:
+```php
+use Kaspi\DiContainer\DiContainerBuilder;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', '/app/src/')
+    ->build()
+;
+```
+Установка созданных экземпляров классов в «runtime definition»:
+```php
+namespace Core;
+
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use App\RuntimeServices\{Foo, Bar};
+
+class Kernel {
+    public function __construct(private DiContainerInterface $container) {}
+    // ...
+    protected function initKernel(): void
+    {
+        // Инициализация класс Foo
+        $foo = new Foo(...\do_calcualte_foo_params());
+        $this->container->set(Foo::class, $foo);
+        // Инициализация класс Bar
+        $bar = new Bar(...\do_calcualte_bar_params());
+        $this->container->set('services.bar', $bar);
     }
 }
 ```

--- a/src/DiContainer/AttributeReader.php
+++ b/src/DiContainer/AttributeReader.php
@@ -8,6 +8,7 @@ use Generator;
 use Kaspi\DiContainer\Attributes\Autowire;
 use Kaspi\DiContainer\Attributes\AutowireExclude;
 use Kaspi\DiContainer\Attributes\DiFactory;
+use Kaspi\DiContainer\Attributes\DiRuntime;
 use Kaspi\DiContainer\Attributes\Inject;
 use Kaspi\DiContainer\Attributes\InjectByCallable;
 use Kaspi\DiContainer\Attributes\Parameter;
@@ -44,28 +45,42 @@ final class AttributeReader
      */
     public static function getDiFactoryAttributeOnClass(ReflectionClass $class): ?DiFactory
     {
-        /** @var ReflectionAttribute<DiFactory>[] $factoryAttrs */
-        $factoryAttrs = $class->getAttributes(DiFactory::class);
+        $factoryAttrs = self::getNotIntersectAttributes($class, DiFactory::class, false, [Autowire::class, DiRuntime::class]);
 
-        if ([] === $factoryAttrs) {
-            return null;
+        return isset($factoryAttrs[0])
+            ? $factoryAttrs[0]->newInstance()
+            : null;
+    }
+
+    /**
+     * Return `DiRuntime::$containerIdentifier` as none-empty string.
+     *
+     * @return Generator<DiRuntime>
+     *
+     * @throws AutowireAttributeException
+     */
+    public static function getDiRuntimeAttribute(ReflectionClass $class): Generator
+    {
+        $diRuntimeAttrs = self::getNotIntersectAttributes($class, DiRuntime::class, true, [DiFactory::class, Autowire::class]);
+
+        $containerIdentifier = '';
+
+        /** @var ReflectionAttribute<DiRuntime> $attr */
+        foreach ($diRuntimeAttrs as $attr) {
+            if ('' === ($diRuntime = $attr->newInstance())->containerIdentifier) {
+                $diRuntime = new DiRuntime($class->name, $diRuntime->message);
+            }
+
+            if ($containerIdentifier === $diRuntime->containerIdentifier) {
+                throw new AutowireAttributeException(
+                    sprintf('Container identifier "%s" already defined via previous php attribute #[%s("%s")] for class "%s".', $containerIdentifier, DiRuntime::class, $containerIdentifier, $class->name),
+                );
+            }
+
+            $containerIdentifier = $diRuntime->containerIdentifier;
+
+            yield $diRuntime;
         }
-
-        if (isset($factoryAttrs[1])) {
-            throw new AutowireAttributeException(
-                sprintf('The attribute %s can be applied once for %s class.', DiFactory::class, $class->name)
-            );
-        }
-
-        $autowireAttrs = $class->getAttributes(Autowire::class);
-
-        if ([] !== $autowireAttrs) {
-            throw new AutowireAttributeException(
-                sprintf('The attributes %s and %s cannot be declared together at class %s.', DiFactory::class, Autowire::class, $class->name)
-            );
-        }
-
-        return $factoryAttrs[0]->newInstance();
     }
 
     /**
@@ -75,23 +90,15 @@ final class AttributeReader
      */
     public static function getAutowireAttribute(ReflectionClass $class): Generator
     {
-        /** @var ReflectionAttribute<Autowire>[] $autowireAttrs */
-        $autowireAttrs = $class->getAttributes(Autowire::class);
+        $autowireAttrs = self::getNotIntersectAttributes($class, Autowire::class, true, [DiRuntime::class, DiFactory::class]);
 
         if ([] === $autowireAttrs) {
             return;
         }
 
-        $factoryAttrs = $class->getAttributes(DiFactory::class);
-
-        if ([] !== $factoryAttrs) {
-            throw new AutowireAttributeException(
-                sprintf('The attributes %s and %s cannot be declared together at class %s.', Autowire::class, DiFactory::class, $class->name)
-            );
-        }
-
         $containerIdentifier = '';
 
+        /** @var ReflectionAttribute<Autowire> $attr */
         foreach ($autowireAttrs as $attr) {
             if ('' === ($autowire = $attr->newInstance())->id) {
                 $autowire = new Autowire($class->name, $autowire->isSingleton, $autowire->arguments);
@@ -234,5 +241,38 @@ final class AttributeReader
 
             yield $attrInit;
         }
+    }
+
+    /**
+     * @template T of Autowire|DiFactory|DiRuntime
+     *
+     * @param class-string<T>    $mainAttribute
+     * @param list<class-string> $notIntersectAttrs
+     *
+     * @return list<ReflectionAttribute<T>>
+     */
+    private static function getNotIntersectAttributes(ReflectionClass $class, string $mainAttribute, bool $isRepeatedMainAttribute, array $notIntersectAttrs): array
+    {
+        $mainAttrs = $class->getAttributes($mainAttribute);
+
+        if ([] === $mainAttrs) {
+            return [];
+        }
+
+        if (!$isRepeatedMainAttribute && isset($mainAttrs[1])) {
+            throw new AutowireAttributeException(
+                sprintf('The attribute %s can be applied once for %s class.', $mainAttribute, $class->name)
+            );
+        }
+
+        foreach ($notIntersectAttrs as $attr) {
+            if ([] !== $class->getAttributes($attr)) {
+                throw new AutowireAttributeException(
+                    sprintf('The attributes %s and %s cannot be declared together at class %s.', $mainAttribute, $attr, $class->name)
+                );
+            }
+        }
+
+        return $mainAttrs;
     }
 }

--- a/src/DiContainer/Attributes/DiRuntime.php
+++ b/src/DiContainer/Attributes/DiRuntime.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class DiRuntime
+{
+    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null) {}
+}

--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -11,10 +11,12 @@ use InvalidArgumentException;
 use Kaspi\DiContainer\Attributes\Autowire;
 use Kaspi\DiContainer\Attributes\AutowireExclude;
 use Kaspi\DiContainer\Attributes\DiFactory;
+use Kaspi\DiContainer\Attributes\DiRuntime;
 use Kaspi\DiContainer\Attributes\Service;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\AutowireParameterTypeException;
 use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
@@ -79,7 +81,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
 
     private bool $useAttribute = true;
 
-    /** @var array<non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet> */
+    /** @var array<non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet|DiDefinitionRuntime> */
     private array $importedDefinitions;
 
     /**
@@ -428,7 +430,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
     }
 
     /**
-     * @return Generator<non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet>
+     * @return Generator<non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet|DiDefinitionRuntime>
      *
      * @throws DefinitionsLoaderException
      */
@@ -514,7 +516,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
     /**
      * @param ItemFQN $itemFQN
      *
-     * @return array<class-string|non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet>
+     * @return array<class-string|non-empty-string, DiDefinitionAutowire|DiDefinitionFactory|DiDefinitionGet|DiDefinitionRuntime>
      *
      * @throws AutowireAttributeException|AutowireParameterTypeException|DefinitionsLoaderInvalidArgumentException
      */
@@ -612,6 +614,26 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
             $diFactory = new DiDefinitionFactory($factory->definition, $factory->isSingleton);
 
             return [$reflectionClass->name => $diFactory->bindArguments(...$factory->arguments)];
+        }
+
+        if (($diRuntimeAttrs = AttributeReader::getDiRuntimeAttribute($reflectionClass))->valid()) {
+            /** @var array<non-empty-string, DiDefinitionRuntime> $diRuntimeServices */
+            $diRuntimeServices = [];
+
+            foreach ($diRuntimeAttrs as $diRuntimeAttr) {
+                /** @var non-empty-string $containerIdentifier */
+                $containerIdentifier = $diRuntimeAttr->containerIdentifier;
+
+                if ($this->configuredDefinitions->offsetExists($containerIdentifier)) {
+                    throw new DefinitionsLoaderInvalidArgumentException(
+                        sprintf('Cannot automatically configure class "%s" via php attribute "%s". Container identifier "%s" already registered. This class "%s" must be configure via php attribute or via config file.', $reflectionClass->name, DiRuntime::class, $containerIdentifier, $reflectionClass->name)
+                    );
+                }
+
+                $diRuntimeServices[$containerIdentifier] = new DiDefinitionRuntime($containerIdentifier, $diRuntimeAttr->message);
+            }
+
+            return $diRuntimeServices;
         }
 
         return $this->configuredDefinitions->offsetExists($reflectionClass->name)

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -8,6 +8,7 @@ use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Exception\CallCircularDependencyException;
 use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
@@ -23,6 +24,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionLinkInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSingletonInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
@@ -201,7 +203,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     }
 
     /**
-     * @return iterable<class-string|non-empty-string, DiDefinitionType>
+     * @return iterable<class-string|non-empty-string, DiDefinitionRuntimeInterface|DiDefinitionType>
      */
     public function getDefinitions(): iterable
     {
@@ -242,7 +244,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     }
 
     /**
-     * @return DiDefinitionInterface&DiDefinitionType
+     * @return (DiDefinitionInterface&DiDefinitionType)|DiDefinitionRuntimeInterface
      */
     public function getDefinition(string $id): DiDefinitionInterface
     {
@@ -358,20 +360,28 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             throw new AutowireException(sprintf('Attempting to resolve interface "%s". An interface that is not bound to a definition.', $id));
         }
 
-        if ($this->config->isUseAttribute()
-            && null !== ($factory = AttributeReader::getDiFactoryAttributeOnClass($reflectionClass))) {
-            $diFactory = new DiDefinitionFactory($factory->definition, $factory->isSingleton);
+        if ($this->config->isUseAttribute()) {
+            if (null !== ($factory = AttributeReader::getDiFactoryAttributeOnClass($reflectionClass))) {
+                $diFactory = new DiDefinitionFactory($factory->definition, $factory->isSingleton);
 
-            return $this->diResolvedDefinition[$id] = $diFactory->bindArguments(...$factory->arguments);
-        }
+                return $this->diResolvedDefinition[$id] = $diFactory->bindArguments(...$factory->arguments);
+            }
 
-        if ($this->config->isUseAttribute()
-            && ($autowires = AttributeReader::getAutowireAttribute($reflectionClass))->valid()) {
-            foreach ($autowires as $autowire) {
-                if ($autowire->id === $reflectionClass->name) {
-                    return $this->diResolvedDefinition[$id] = (new DiDefinitionAutowire($reflectionClass, $autowire->isSingleton))
-                        ->bindArguments(...$autowire->arguments)
-                    ;
+            if (($autowires = AttributeReader::getAutowireAttribute($reflectionClass))->valid()) {
+                foreach ($autowires as $autowire) {
+                    if ($autowire->id === $reflectionClass->name) {
+                        return $this->diResolvedDefinition[$id] = (new DiDefinitionAutowire($reflectionClass, $autowire->isSingleton))
+                            ->bindArguments(...$autowire->arguments)
+                        ;
+                    }
+                }
+            }
+
+            if (($diRuntimes = AttributeReader::getDiRuntimeAttribute($reflectionClass))->valid()) {
+                foreach ($diRuntimes as $diRuntime) {
+                    if ($diRuntime->containerIdentifier === $reflectionClass->name) {
+                        return $this->diResolvedDefinition[$id] = new DiDefinitionRuntime($diRuntime->containerIdentifier, $diRuntime->message);
+                    }
                 }
             }
         }

--- a/tests/AttributeReader/Autowire/AutowireTest.php
+++ b/tests/AttributeReader/Autowire/AutowireTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Tests\AttributeReader\Autowire\Fixtures\ClassWithDiFactoryAndAutowire;
+use Tests\AttributeReader\Autowire\Fixtures\Foo;
 use Tests\AttributeReader\Autowire\Fixtures\MultipleAutowire;
 use Tests\AttributeReader\Autowire\Fixtures\MultipleAutowireFail;
 
@@ -66,5 +67,13 @@ class AutowireTest extends TestCase
         $this->expectExceptionMessageMatches('/Container identifier "service" already defined/');
 
         iterator_to_array($attrs);
+    }
+
+    public function testAutowireAndDiRuntime(): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/The attributes .+Autowire and .+DiRuntime cannot be declared together/');
+
+        [...AttributeReader::getAutowireAttribute(new ReflectionClass(Foo::class))];
     }
 }

--- a/tests/AttributeReader/Autowire/Fixtures/Foo.php
+++ b/tests/AttributeReader/Autowire/Fixtures/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\Autowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[Autowire]
+#[DiRuntime]
+final class Foo {}

--- a/tests/AttributeReader/DiFactory/DiFactoryReaderTest.php
+++ b/tests/AttributeReader/DiFactory/DiFactoryReaderTest.php
@@ -16,6 +16,7 @@ use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionParameter;
 use Tests\AttributeReader\DiFactory\Fixtures\ClassWithAttrsDiFactoryAndAutowire;
+use Tests\AttributeReader\DiFactory\Fixtures\Foo;
 use Tests\AttributeReader\DiFactory\Fixtures\FooFactoryOne;
 use Tests\AttributeReader\DiFactory\Fixtures\FooFactoryTwo;
 use Tests\AttributeReader\DiFactory\Fixtures\FooFactoryWithArgs;
@@ -131,5 +132,13 @@ class DiFactoryReaderTest extends TestCase
         self::assertEquals([
             'apiKey' => new DiDefinitionGet('keys.api_key'),
         ], $factory->arguments);
+    }
+
+    public function testCannotUseTogetherDiFactoryAndDiRuntime(): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/The attributes .+DiFactory and .+DiRuntime cannot be declared together/');
+
+        AttributeReader::getDiFactoryAttributeOnClass(new ReflectionClass(Foo::class));
     }
 }

--- a/tests/AttributeReader/DiFactory/Fixtures/Foo.php
+++ b/tests/AttributeReader/DiFactory/Fixtures/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiFactory\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiFactory;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiFactory(FooFactoryOne::class)]
+#[DiRuntime]
+final class Foo {}

--- a/tests/AttributeReader/DiRuntime/DiRuntimeReaderTest.php
+++ b/tests/AttributeReader/DiRuntime/DiRuntimeReaderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiRuntime;
+
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Tests\AttributeReader\DiRuntime\Fixtures\Bar;
+use Tests\AttributeReader\DiRuntime\Fixtures\Baz;
+use Tests\AttributeReader\DiRuntime\Fixtures\Foo;
+use Tests\AttributeReader\DiRuntime\Fixtures\FooInvalid;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(DiRuntime::class)]
+class DiRuntimeReaderTest extends TestCase
+{
+    #[TestWith([Bar::class, '/The attributes .+DiRuntime and .+Autowire cannot be declared together/'])]
+    #[TestWith([Baz::class, '/The attributes .+DiRuntime and .+DiFactory cannot be declared together/'])]
+    #[TestWith([FooInvalid::class, '/Container identifier.+".+FooInvalid" already defined via previous php attribute/'])]
+    public function testIntersectAttrs(string $class, string $expectMessageMatch): void
+    {
+        $this->expectException(AutowireExceptionInterface::class);
+        $this->expectExceptionMessageMatches($expectMessageMatch);
+
+        [...AttributeReader::getDiRuntimeAttribute(new ReflectionClass($class))];
+    }
+
+    public function testReadAllDiRuntimeAttrs(): void
+    {
+        /** @var list<DiRuntime> $attrs */
+        $attrs = [...AttributeReader::getDiRuntimeAttribute(new ReflectionClass(Foo::class))];
+
+        self::assertCount(2, $attrs);
+        self::assertEquals('foo', $attrs[0]->containerIdentifier);
+        self::assertEquals(Foo::class, $attrs[1]->containerIdentifier);
+    }
+}

--- a/tests/AttributeReader/DiRuntime/Fixtures/Bar.php
+++ b/tests/AttributeReader/DiRuntime/Fixtures/Bar.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+#[Autowire]
+final class Bar {}

--- a/tests/AttributeReader/DiRuntime/Fixtures/Baz.php
+++ b/tests/AttributeReader/DiRuntime/Fixtures/Baz.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiFactory;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+#[DiFactory('\log')]
+final class Baz {}

--- a/tests/AttributeReader/DiRuntime/Fixtures/Foo.php
+++ b/tests/AttributeReader/DiRuntime/Fixtures/Foo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime('foo')]
+#[DiRuntime]
+final class Foo {}

--- a/tests/AttributeReader/DiRuntime/Fixtures/FooInvalid.php
+++ b/tests/AttributeReader/DiRuntime/Fixtures/FooInvalid.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AttributeReader\DiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+#[DiRuntime]
+final class FooInvalid {}

--- a/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\ImportDiRuntime;
+
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\DefinitionsLoader;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\Finder\FinderFile;
+use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
+use Kaspi\DiContainer\FinderFullyQualifiedNameCollection;
+use Kaspi\DiContainer\Helper;
+use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+use Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success\Bar;
+use Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success\Foo;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(DefinitionsLoader::class)]
+#[CoversClass(DiRuntime::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(FinderFullyQualifiedNameCollection::class)]
+#[CoversClass(FinderFile::class)]
+#[CoversClass(FinderFullyQualifiedName::class)]
+#[CoversClass(Helper::class)]
+#[CoversFunction('Kaspi\DiContainer\diRuntime')]
+class DefinitionsLoaderImportDiRuntimeTest extends TestCase
+{
+    public function testImportDiRuntimeSucceeds(): void
+    {
+        $loader = (new DefinitionsLoader())
+            ->import(
+                'Tests\DefinitionsLoader\ImportDiRuntime\\',
+                __DIR__.'/Fixtures/Success',
+            )
+        ;
+
+        $definitions = [...$loader->definitions()];
+
+        self::assertCount(3, $definitions);
+
+        self::assertEquals(Foo::class, $definitions[Foo::class]->getIdentifier());
+        self::assertEquals(Bar::class, $definitions[Bar::class]->getIdentifier());
+        self::assertEquals('services.bar', $definitions['services.bar']->getIdentifier());
+    }
+
+    public function testImportDiRuntimeAndDefinedDiRuntimeConflict(): void
+    {
+        $this->expectException(DefinitionsLoaderExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/Cannot automatically configure class.+Container identifier "services\.bar" already registered/');
+
+        $loader = (new DefinitionsLoader())
+            ->import(
+                'Tests\DefinitionsLoader\ImportDiRuntime\\',
+                __DIR__.'/Fixtures/Success',
+            )
+            ->addDefinitions(true, [
+                \Kaspi\DiContainer\diRuntime('services.bar'),
+            ])
+        ;
+
+        [...$loader->definitions()];
+    }
+
+    public function testImportDiRuntimeWithConflictOtherClassAttributes(): void
+    {
+        $this->expectException(DefinitionsLoaderExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/The attributes .+\\\Autowire and .+\\\DiRuntime cannot be declared together/');
+
+        $loader = (new DefinitionsLoader())
+            ->import(
+                'Tests\DefinitionsLoader\ImportDiRuntime\\',
+                __DIR__.'/Fixtures/Fail',
+            )
+        ;
+
+        [...$loader->definitions()];
+    }
+}

--- a/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Fail/Foo.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Fail/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Fail;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[Autowire('services.foo_autowire')]
+#[DiRuntime('services.foo_runtime')]
+final class Foo {}

--- a/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Bar.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Bar.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+#[DiRuntime('services.bar')]
+final class Bar {}

--- a/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Foo.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+final class Foo {}

--- a/tests/DiContainer/ResolveByDiRuntime/Fixtures/Bar.php
+++ b/tests/DiContainer/ResolveByDiRuntime/Fixtures/Bar.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiContainer\ResolveByDiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime('services.bar')]
+final class Bar {}

--- a/tests/DiContainer/ResolveByDiRuntime/Fixtures/Foo.php
+++ b/tests/DiContainer/ResolveByDiRuntime/Fixtures/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiContainer\ResolveByDiRuntime\Fixtures;
+
+use Kaspi\DiContainer\Attributes\DiRuntime;
+
+#[DiRuntime]
+final class Foo {}

--- a/tests/DiContainer/ResolveByDiRuntime/ResolveByDiRuntimeTest.php
+++ b/tests/DiContainer/ResolveByDiRuntime/ResolveByDiRuntimeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiContainer\ResolveByDiRuntime;
+
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\DiContainer;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
+use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
+use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
+use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Tests\DiContainer\ResolveByDiRuntime\Fixtures\Bar;
+use Tests\DiContainer\ResolveByDiRuntime\Fixtures\Foo;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(DiRuntime::class)]
+#[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(AbstractSourceDefinitionsMutable::class)]
+#[CoversClass(ImmediateSourceDefinitionsMutable::class)]
+#[CoversClass(DiContainerConfig::class)]
+#[CoversClass(DiContainer::class)]
+class ResolveByDiRuntimeTest extends TestCase
+{
+    private DiContainer $diContainer;
+
+    protected function setUp(): void
+    {
+        $config = new DiContainerConfig(
+            useZeroConfigurationDefinition: true,
+            useAttribute: true
+        );
+
+        $this->diContainer = new DiContainer(config: $config);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->diContainer);
+    }
+
+    public function testResolveByDiRuntime(): void
+    {
+        self::assertInstanceOf(DiDefinitionAutowireInterface::class, $this->diContainer->getDefinition(Bar::class));
+        self::assertInstanceOf(DiDefinitionRuntimeInterface::class, $this->diContainer->getDefinition(Foo::class));
+    }
+
+    public function testGetRuntimeDefinitionFail(): void
+    {
+        $this->expectException(ContainerExceptionInterface::class);
+        $this->expectExceptionMessage('You should replace the value of definition in the runtime container');
+
+        self::assertTrue($this->diContainer->has(Foo::class));
+
+        $this->diContainer->get(Foo::class);
+    }
+
+    public function testGetRuntimeDefinitionSuccess(): void
+    {
+        $this->diContainer->getDefinition(Foo::class)
+            ->setDefinition(new Foo())
+        ;
+
+        self::assertInstanceOf(Foo::class, $this->diContainer->get(Foo::class));
+    }
+}


### PR DESCRIPTION
1. Resolve #564 

- [x] `\Kaspi\DiContainer\AttributeReader` для чтения атрибута `DiRuntime`
- [x] Нельзя использовать одновременно на классе `DiRuntime`, `Autowire`, `DiFactory`
- [x] `DefinitionsLoader` должен уметь читать атрибут `DiRuntime` на классе и преобразовывать в `DiDefinitionRuntime`
- [x] `DiContainer` должен уметь читать `DiRuntime` на классе  при конфигурации с атрибутами и настройкой `DiContainerConfigInterface::isUseZeroConfigurationDefinition() === true`
- [x] Обновление документации по использованию атрибута `DiRuntime` в конфигурировании контейнера