### PR TITLE
Revert "Fixed check tagged definition in definitions configurator."

### DIFF
--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -28,7 +28,6 @@ use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
 use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
 use Kaspi\DiContainer\Interfaces\DefinitionsLoaderInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Finder\FinderFullyQualifiedNameInterface;
@@ -267,23 +266,23 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
                         continue;
                     }
 
-                    $hasTagOnObject = false;
+                    $hasTagOnAutowire = false;
 
-                    if ($definition instanceof DiTaggedObjectDefinitionInterface) {
+                    if ($definition instanceof DiDefinitionAutowire) {
                         $tagIsInterface ??= interface_exists($tag);
-                        $hasTagOnObject = $tagIsInterface && $definition->isImplementInterface($tag);
+                        $hasTagOnAutowire = $tagIsInterface && $definition->getDefinition()->implementsInterface($tag);
 
-                        if (!$tagIsInterface && !$hasTagOnObject) {
-                            $hasTagOnObject = ($this->definitionsLoader->isUseAttribute() && isset($definition->getTagsByAttribute()[$tag]))
+                        if (!$tagIsInterface && !$hasTagOnAutowire) {
+                            $hasTagOnAutowire = ($this->definitionsLoader->isUseAttribute() && isset($definition->getTagsByAttribute()[$tag]))
                                 || isset($definition->getBoundTags()[$tag]);
                         }
 
-                        if (!$hasTagOnObject) {
+                        if (!$hasTagOnAutowire) {
                             continue;
                         }
                     }
 
-                    if ($hasTagOnObject || $definition->hasTag($tag)) {
+                    if ($hasTagOnAutowire || $definition->hasTag($tag)) {
                         yield $identifier => $definition;
                     }
                 }

--- a/src/DiContainer/Interfaces/DefinitionsConfiguratorInterface.php
+++ b/src/DiContainer/Interfaces/DefinitionsConfiguratorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Interfaces;
 
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
-use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\NotFoundDefinitionInterface;
@@ -48,7 +47,7 @@ interface DefinitionsConfiguratorInterface
     /**
      * @param non-empty-string $tag
      *
-     * @return iterable<non-empty-string, DiDefinitionTagArgumentInterface|DiTaggedDefinitionInterface>
+     * @return iterable<non-empty-string, DiTaggedDefinitionInterface>
      */
     public function findTaggedDefinition(string $tag): iterable;
 

--- a/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
@@ -6,18 +6,13 @@ namespace Tests\DefinitionsLoader\ImportDiRuntime;
 
 use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\Attributes\DiRuntime;
-use Kaspi\DiContainer\Attributes\Tag;
 use Kaspi\DiContainer\DefinitionsLoader;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Finder\FinderFile;
 use Kaspi\DiContainer\Finder\FinderFullyQualifiedName;
 use Kaspi\DiContainer\FinderFullyQualifiedNameCollection;
 use Kaspi\DiContainer\Helper;
-use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
-use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
-use Kaspi\DiContainer\Traits\TagsTrait;
-use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
@@ -35,8 +30,6 @@ use Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success\Foo;
 #[CoversClass(FinderFile::class)]
 #[CoversClass(FinderFullyQualifiedName::class)]
 #[CoversClass(Helper::class)]
-#[CoversClass(Tag::class)]
-#[CoversClass(TagsTrait::class)]
 #[CoversFunction('Kaspi\DiContainer\diRuntime')]
 class DefinitionsLoaderImportDiRuntimeTest extends TestCase
 {
@@ -89,45 +82,5 @@ class DefinitionsLoaderImportDiRuntimeTest extends TestCase
         ;
 
         [...$loader->definitions()];
-    }
-
-    public function testConfiguratorFindTagged(): void
-    {
-        vfsStream::setup('root', structure: [
-            'services.php' => '<?php
-return static function (\Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface $configurator) {
-    foreach ($configurator->findTaggedDefinition("tags.bar_service") as $definition) {
-        $definition->bindTag("tags.config");
-    }
-};',
-        ]);
-        $loader = (new DefinitionsLoader())
-            ->useAttribute(true)
-            ->import(
-                'Tests\DefinitionsLoader\ImportDiRuntime\\',
-                __DIR__.'/Fixtures/Success',
-            )
-            ->load(vfsStream::url('root/services.php'))
-        ;
-
-        $defs = [...$loader->definitions()];
-
-        $config = $this->createMock(DiContainerConfigInterface::class);
-        $config->method('isUseAttribute')->willReturn(true);
-
-        $container = $this->createMock(DiContainerInterface::class);
-        $container->method('getConfig')
-            ->willReturn($config)
-        ;
-
-        self::assertCount(3, $defs);
-
-        $foo = $defs[Foo::class]->setContainer($container);
-
-        self::assertFalse($foo->hasTag('tags.config'));
-        self::assertTrue($foo->hasTag('tags.foo_service'));
-
-        self::assertTrue($defs[Bar::class]->setContainer($container)->hasTag('tags.config'));
-        self::assertTrue($defs['services.bar']->setContainer($container)->hasTag('tags.config'));
     }
 }

--- a/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Bar.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Bar.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success;
 
 use Kaspi\DiContainer\Attributes\DiRuntime;
-use Kaspi\DiContainer\Attributes\Tag;
 
 #[DiRuntime]
 #[DiRuntime('services.bar')]
-#[Tag('tags.bar_service')]
 final class Bar {}

--- a/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Foo.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/Fixtures/Success/Foo.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Tests\DefinitionsLoader\ImportDiRuntime\Fixtures\Success;
 
 use Kaspi\DiContainer\Attributes\DiRuntime;
-use Kaspi\DiContainer\Attributes\Tag;
 
 #[DiRuntime]
-#[Tag('tags.foo_service')]
 final class Foo {}


### PR DESCRIPTION
Reverts agdobrynin/di-container#573

`\Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface::findTaggedDefinition()` should return only DiTaggedDefinitionInterface.