### PR TITLE
Rename interface `ContainerAlreadyRegisteredExceptionInterface` and class `ContainerAlreadyRegisteredException`.

### DIFF
--- a/docs/06-container-builder.md
+++ b/docs/06-container-builder.md
@@ -577,7 +577,7 @@ $container = $builder->build();
 - `$definition` – определение соответствующее идентификатору `$id`;
 
 > [!WARNING] 
-> Если идентификатор контейнера не уникален в рамках текущего контейнера, то будет выброшено исключение `\Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface`.
+> Если идентификатор контейнера не уникален в рамках текущего контейнера, то будет выброшено исключение `\Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface`.
 
 > [!WARNING]
 > Рекомендуется использовать [файлы конфигурации](#загрузка-из-файлов-конфигураций),

--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -19,7 +19,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\AutowireParameterTypeException;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\DefinitionsLoaderException;
 use Kaspi\DiContainer\Exception\DefinitionsLoaderInvalidArgumentException;
 use Kaspi\DiContainer\Exception\NotFoundDefinition;
@@ -131,7 +131,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
             }
 
             if (!$overrideDefinitions && $this->configuredDefinitions->offsetExists($identifier)) {
-                throw new ContainerAlreadyRegisteredException(
+                throw new ContainerIdentifierAlreadyRegisteredException(
                     sprintf('Item position #%d.', $itemCount),
                     id: $identifier
                 );
@@ -725,7 +725,7 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
 
             try {
                 $this->addDefinitions($overrideDefinitions, $this->getDefinitionsFromFile($srcFile));
-            } catch (ContainerAlreadyRegisteredException|DefinitionsLoaderExceptionInterface $e) {
+            } catch (ContainerIdentifierAlreadyRegisteredException|DefinitionsLoaderExceptionInterface $e) {
                 throw new DefinitionsLoaderInvalidArgumentException(
                     message: sprintf('Invalid definition in file "%s".', $srcFile),
                     previous: $e

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -11,8 +11,8 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireException;
 use Kaspi\DiContainer\Exception\CallCircularDependencyException;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\ContainerException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Interfaces\DiContainerCallInterface;
@@ -30,7 +30,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\ResetInterface;
 use Kaspi\DiContainer\Interfaces\SourceDefinitionsMutableInterface;
@@ -106,7 +106,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      * @param iterable<non-empty-string, SourceParameterType>|SourceParametersMutableInterface   $parameters
      *
      * @throws ContainerIdentifierExceptionInterface
-     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface
      */
     public function __construct(
         iterable|SourceDefinitionsMutableInterface $definitions = [],
@@ -141,7 +141,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     public function set(string $id, mixed $definition): static
     {
         if (isset($this->containerIds[$id])) {
-            throw new ContainerAlreadyRegisteredException(id: $id);
+            throw new ContainerIdentifierAlreadyRegisteredException(id: $id);
         }
 
         $this->definitions->set($id, $definition);

--- a/src/DiContainer/DiContainerBuilder.php
+++ b/src/DiContainer/DiContainerBuilder.php
@@ -25,7 +25,7 @@ use Kaspi\DiContainer\Interfaces\DiContainerConfigInterface;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiContainerSetterInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\ResetInterface;
 use Kaspi\DiContainer\Parameters\DeferredSourceParameters;
@@ -382,7 +382,7 @@ final class DiContainerBuilder implements DiContainerBuilderInterface
                     $definitions['override'],
                     $definitions['definitions'],
                 );
-            } catch (ContainerAlreadyRegisteredExceptionInterface|DefinitionsLoaderExceptionInterface $e) {
+            } catch (ContainerIdentifierAlreadyRegisteredExceptionInterface|DefinitionsLoaderExceptionInterface $e) {
                 $useMethod = $definitions['override']
                     ? 'addDefinitionsOverride()'
                     : 'addDefinitions()';

--- a/src/DiContainer/Exception/ContainerIdentifierAlreadyRegisteredException.php
+++ b/src/DiContainer/Exception/ContainerIdentifierAlreadyRegisteredException.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Exception;
 
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Throwable;
 
 use function rtrim;
 use function sprintf;
 use function var_export;
 
-class ContainerAlreadyRegisteredException extends ContainerException implements ContainerAlreadyRegisteredExceptionInterface
+class ContainerIdentifierAlreadyRegisteredException extends ContainerException implements ContainerIdentifierAlreadyRegisteredExceptionInterface
 {
     public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null, string $id = '')
     {

--- a/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
+++ b/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces;
 
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
@@ -43,7 +43,7 @@ interface DefinitionsLoaderInterface extends ResetInterface
      *
      * @return $this
      *
-     * @throws ContainerAlreadyRegisteredException|DefinitionsLoaderExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredException|DefinitionsLoaderExceptionInterface
      */
     public function addDefinitions(bool $overrideDefinitions, iterable $definitions): static;
 

--- a/src/DiContainer/Interfaces/DiContainerFactoryInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerFactoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\Interfaces;
 
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 
 interface DiContainerFactoryInterface
@@ -13,7 +13,7 @@ interface DiContainerFactoryInterface
     /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
      *
-     * @throws ContainerAlreadyRegisteredExceptionInterface|ContainerIdentifierExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface|ContainerIdentifierExceptionInterface
      */
     public function make(
         iterable $definitions = [],

--- a/src/DiContainer/Interfaces/DiContainerSetterInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerSetterInterface.php
@@ -12,7 +12,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSingletonInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedDefinitionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 
@@ -22,7 +22,7 @@ interface DiContainerSetterInterface
      * @param class-string|non-empty-string                                                                                                                                                                                                                                $id
      * @param DiDefinitionArgumentsInterface|DiDefinitionAutowireInterface|DiDefinitionInterface|DiDefinitionSetupAutowireInterface|DiDefinitionSingletonInterface|DiDefinitionTagArgumentInterface|DiDefinitionTaggedAsInterface|DiTaggedDefinitionInterface|mixed|object $definition
      *
-     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface
      * @throws ContainerIdentifierExceptionInterface
      * @throws DiDefinitionExceptionInterface
      */

--- a/src/DiContainer/Interfaces/Exceptions/ContainerIdentifierAlreadyRegisteredExceptionInterface.php
+++ b/src/DiContainer/Interfaces/Exceptions/ContainerIdentifierAlreadyRegisteredExceptionInterface.php
@@ -6,4 +6,4 @@ namespace Kaspi\DiContainer\Interfaces\Exceptions;
 
 use Psr\Container\ContainerExceptionInterface;
 
-interface ContainerAlreadyRegisteredExceptionInterface extends ContainerExceptionInterface {}
+interface ContainerIdentifierAlreadyRegisteredExceptionInterface extends ContainerExceptionInterface {}

--- a/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
+++ b/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
@@ -6,7 +6,7 @@ namespace Kaspi\DiContainer\Interfaces;
 
 use IteratorAggregate;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Traversable;
@@ -20,7 +20,7 @@ interface SourceDefinitionsMutableInterface extends IteratorAggregate, ResetInte
     /**
      * @param int|non-empty-string $id
      *
-     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface
      * @throws ContainerIdentifierExceptionInterface
      * @throws DiDefinitionExceptionInterface
      */

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\SourceDefinitions;
 
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
@@ -45,7 +45,7 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
 
         if (null !== $definition) {
             if (!$definition instanceof DiDefinitionRuntimeInterface) {
-                throw new ContainerAlreadyRegisteredException(
+                throw new ContainerIdentifierAlreadyRegisteredException(
                     sprintf('Definition type: "%s".', get_debug_type($value)),
                     id: $item->containerIdentifier,
                 );

--- a/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer\SourceDefinitions;
 
 use Closure;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 
 use function get_debug_type;
 use function sprintf;
@@ -55,7 +55,7 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
                 $item = new SourceDefinitionItem($identifier, $sourceDefinition, false);
 
                 if (isset($this->definitions[$item->containerIdentifier])) {
-                    throw new ContainerAlreadyRegisteredException(
+                    throw new ContainerIdentifierAlreadyRegisteredException(
                         sprintf('Definition type: "%s".', get_debug_type($sourceDefinition)),
                         id: $item->containerIdentifier,
                     );

--- a/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\SourceDefinitions;
 
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 
 use function get_debug_type;
@@ -23,7 +23,7 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
      * @param iterable<non-empty-string|non-negative-int, mixed> $sourceDefinitions
      * @param iterable<class-string|non-empty-string, mixed>     $sourceRemovedDefinitionIds
      *
-     * @throws ContainerAlreadyRegisteredExceptionInterface
+     * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface
      * @throws ContainerIdentifierExceptionInterface
      */
     public function __construct(iterable $sourceDefinitions, iterable $sourceRemovedDefinitionIds = [])
@@ -35,7 +35,7 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
             $item = new SourceDefinitionItem($identifier, $sourceDefinition, false);
 
             if (isset($this->definitions[$item->containerIdentifier])) {
-                throw new ContainerAlreadyRegisteredException(
+                throw new ContainerIdentifierAlreadyRegisteredException(
                     sprintf('Definition type: "%s".', get_debug_type($sourceDefinition)),
                     id: $item->containerIdentifier,
                 );

--- a/tests/DefinitionsLoader/DefinitionsLoaderTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderTest.php
@@ -7,11 +7,11 @@ namespace Tests\DefinitionsLoader;
 use Generator;
 use Kaspi\DiContainer\DefinitionsLoader;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\ContainerIdentifierException;
 use Kaspi\DiContainer\Exception\DefinitionsLoaderException;
 use Kaspi\DiContainer\Helper;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ContainerIdentifierException::class)]
 #[CoversClass(DefinitionsLoaderException::class)]
 #[CoversClass(Helper::class)]
-#[CoversClass(ContainerAlreadyRegisteredException::class)]
+#[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 class DefinitionsLoaderTest extends TestCase
 {
     #[DataProvider('dataProviderInvalidContent')]
@@ -92,7 +92,7 @@ class DefinitionsLoaderTest extends TestCase
 
     public function testContainerIdentifierAlreadyRegistered(): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
 
         $config = static function (): Generator {
             yield 'services.foo' => 'foo';

--- a/tests/DiContainer/ResolveSelfContainerTest.php
+++ b/tests/DiContainer/ResolveSelfContainerTest.php
@@ -8,11 +8,11 @@ use Generator;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerConfig;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
@@ -34,7 +34,7 @@ use stdClass;
 #[CoversClass(ImmediateSourceParameters::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(Helper::class)]
-#[CoversClass(ContainerAlreadyRegisteredException::class)]
+#[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 #[CoversClass(NotFoundException::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 class ResolveSelfContainerTest extends TestCase
@@ -54,7 +54,7 @@ class ResolveSelfContainerTest extends TestCase
     #[DataProvider('dataProvider')]
     public function testSetReservedId(string $id): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
 
         (new DiContainer())->set($id, new stdClass());
     }

--- a/tests/DiContainer/Set/DiContainerSetTest.php
+++ b/tests/DiContainer/Set/DiContainerSetTest.php
@@ -7,10 +7,10 @@ namespace Tests\DiContainer\Set;
 use Generator;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\ContainerIdentifierException;
 use Kaspi\DiContainer\Helper;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
@@ -31,7 +31,7 @@ use stdClass;
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
-#[CoversClass(ContainerAlreadyRegisteredException::class)]
+#[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 class DiContainerSetTest extends TestCase
 {
@@ -69,7 +69,7 @@ class DiContainerSetTest extends TestCase
     {
         $container = (new DiContainer())->set('key', 'value');
 
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
 
         $container->set('key', 'value2');
     }

--- a/tests/SourceDefinitionsMutable/DeferredSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/DeferredSourceDefinitionsMutableTest.php
@@ -9,9 +9,9 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Helper;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
@@ -33,7 +33,7 @@ use function array_keys;
 #[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(Helper::class)]
-#[CoversClass(ContainerAlreadyRegisteredException::class)]
+#[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 class DeferredSourceDefinitionsMutableTest extends TestCase
 {
@@ -110,7 +110,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
     public function testSetFail(): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
         $this->expectExceptionMessage('The container identifier \'service.bar\' already registered in the source.');
 
         $s = new DeferredSourceDefinitionsMutable(static fn () => ['service.bar' => 'Service bar']);
@@ -218,7 +218,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
     public function testKeyExistThroughConstructor(): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
         $this->expectExceptionMessage('The container identifier \'service.foo\' already registered in the source.');
 
         $defs = static function (): Generator {

--- a/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
@@ -9,9 +9,9 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
-use Kaspi\DiContainer\Exception\ContainerAlreadyRegisteredException;
+use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Helper;
-use Kaspi\DiContainer\Interfaces\Exceptions\ContainerAlreadyRegisteredExceptionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
@@ -33,7 +33,7 @@ use function array_keys;
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(Helper::class)]
-#[CoversClass(ContainerAlreadyRegisteredException::class)]
+#[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 class ImmediateSourceDefinitionsMutableTest extends TestCase
 {
@@ -101,7 +101,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
 
     public function testSetFail(): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
         $this->expectExceptionMessage('The container identifier \'service.bar\' already registered in the source.');
 
         $s = new ImmediateSourceDefinitionsMutable(['service.bar' => 'Service bar']);
@@ -118,7 +118,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
 
     public function testKeyExistThroughConstructor(): void
     {
-        $this->expectException(ContainerAlreadyRegisteredExceptionInterface::class);
+        $this->expectException(ContainerIdentifierAlreadyRegisteredExceptionInterface::class);
         $this->expectExceptionMessage('The container identifier \'service.foo\' already registered in the source.');
 
         $defs = static function (): Generator {


### PR DESCRIPTION
- Resolve #588 