### PR TITLE
Refactoring removed definition IDs

### DIFF
--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -58,8 +58,8 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
             },
 <?php if ($container->getRemovedDefinitionIds()->valid()) { ?>
             removedDefinitionIds: (static function (): \Generator {
-<?php foreach ($container->getRemovedDefinitionIds() as $id => $v) {?>
-                <?php echo \sprintf('yield %s => true;'.PHP_EOL, \var_export($id, true))?>
+<?php foreach ($container->getRemovedDefinitionIds() as $id) {?>
+                <?php echo \sprintf('yield %s;'.PHP_EOL, \var_export($id, true))?>
 <?php } ?>
             })()
 <?php } ?>

--- a/src/DiContainer/DefinitionsLoader.php
+++ b/src/DiContainer/DefinitionsLoader.php
@@ -358,7 +358,9 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
     public function removedDefinitionIds(): iterable
     {
         if ($this->isRemovedDefinitionsImported) {
-            yield from $this->removedDefinitionIds;
+            foreach ($this->removedDefinitionIds as $removedDefinitionId => $v) {
+                yield $removedDefinitionId;
+            }
 
             return;
         }
@@ -366,7 +368,9 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
         if (null === $this->finderFullyQualifiedNameCollection) {
             $this->isRemovedDefinitionsImported = true;
 
-            yield from $this->removedDefinitionIds;
+            foreach ($this->removedDefinitionIds as $removedDefinitionId => $v) {
+                yield $removedDefinitionId;
+            }
 
             return;
         }
@@ -407,7 +411,9 @@ final class DefinitionsLoader implements DefinitionsLoaderInterface
 
         $this->isRemovedDefinitionsImported = true;
 
-        yield from $this->removedDefinitionIds;
+        foreach ($this->removedDefinitionIds as $removedDefinitionId => $v) {
+            yield $removedDefinitionId;
+        }
     }
 
     public function reset(): void

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -102,7 +102,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
     /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
-     * @param iterable<class-string|non-empty-string, mixed>                                     $removedDefinitionIds
+     * @param iterable<class-string|non-empty-string>                                            $removedDefinitionIds
      * @param iterable<non-empty-string, SourceParameterType>|SourceParametersMutableInterface   $parameters
      *
      * @throws ContainerIdentifierExceptionInterface

--- a/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
+++ b/src/DiContainer/Interfaces/DefinitionsLoaderInterface.php
@@ -83,7 +83,7 @@ interface DefinitionsLoaderInterface extends ResetInterface
     public function definitions(): iterable;
 
     /**
-     * @return iterable<class-string|non-empty-string, true>
+     * @return iterable<class-string|non-empty-string>
      *
      * @throws DefinitionsLoaderExceptionInterface
      */

--- a/src/DiContainer/Interfaces/DiContainerInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerInterface.php
@@ -67,7 +67,7 @@ interface DiContainerInterface extends ContainerInterface
     /**
      * Returns container identifiers mark as deleted from  resolving.
      *
-     * @return iterable<class-string|non-empty-string, true>
+     * @return iterable<class-string|non-empty-string>
      */
     public function getRemovedDefinitionIds(): iterable;
 

--- a/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
+++ b/src/DiContainer/Interfaces/SourceDefinitionsMutableInterface.php
@@ -37,7 +37,7 @@ interface SourceDefinitionsMutableInterface extends IteratorAggregate, ResetInte
     public function isRemovedDefinition(string $id): bool;
 
     /**
-     * @return iterable<class-string|non-empty-string, true>
+     * @return iterable<class-string|non-empty-string>
      */
     public function getRemovedDefinitionIds(): iterable;
 }

--- a/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/AbstractSourceDefinitionsMutable.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\Interfaces\ResetInterface;
 use Kaspi\DiContainer\Interfaces\SourceDefinitionsMutableInterface;
 use Traversable;
 
+use function array_keys;
 use function get_debug_type;
 use function is_object;
 use function sprintf;
@@ -69,7 +70,7 @@ abstract class AbstractSourceDefinitionsMutable implements SourceDefinitionsMuta
 
     public function getRemovedDefinitionIds(): iterable
     {
-        return $this->initializerRemovedIds();
+        yield from array_keys($this->initializerRemovedIds());
     }
 
     public function reset(): void

--- a/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/DeferredSourceDefinitionsMutable.php
@@ -15,7 +15,7 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
     /** @var ?Closure(): iterable<(class-string|non-empty-string|non-negative-int), mixed> */
     private ?Closure $sourceDefinitions;
 
-    /** @var null|Closure(): iterable<(class-string|non-empty-string), mixed> */
+    /** @var null|Closure(): iterable<class-string|non-empty-string> */
     private ?Closure $sourceRemovedDefinitionIds;
 
     /** @var array<class-string|non-empty-string, SourceDefinitionItem> */
@@ -26,7 +26,7 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
 
     /**
      * @param callable(): iterable<(class-string|non-empty-string|non-negative-int), mixed> $sourceDefinitions
-     * @param null|callable(): iterable<(class-string|non-empty-string), mixed>             $sourceRemovedDefinitionIds
+     * @param null|callable(): iterable<class-string|non-empty-string>                      $sourceRemovedDefinitionIds
      */
     public function __construct(callable $sourceDefinitions, ?callable $sourceRemovedDefinitionIds = null)
     {
@@ -65,7 +65,7 @@ final class DeferredSourceDefinitionsMutable extends AbstractSourceDefinitionsMu
             }
 
             if (null !== $this->sourceRemovedDefinitionIds) {
-                foreach (($this->sourceRemovedDefinitionIds)() as $identifier => $v) {
+                foreach (($this->sourceRemovedDefinitionIds)() as $identifier) {
                     $this->removedDefinitionIds[$identifier] = true;
                     unset($this->definitions[$identifier]);
                 }

--- a/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
+++ b/src/DiContainer/SourceDefinitions/ImmediateSourceDefinitionsMutable.php
@@ -21,7 +21,7 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
 
     /**
      * @param iterable<non-empty-string|non-negative-int, mixed> $sourceDefinitions
-     * @param iterable<class-string|non-empty-string, mixed>     $sourceRemovedDefinitionIds
+     * @param iterable<class-string|non-empty-string>            $sourceRemovedDefinitionIds
      *
      * @throws ContainerIdentifierAlreadyRegisteredExceptionInterface
      * @throws ContainerIdentifierExceptionInterface
@@ -44,7 +44,7 @@ final class ImmediateSourceDefinitionsMutable extends AbstractSourceDefinitionsM
             $this->definitions[$item->containerIdentifier] = $item;
         }
 
-        foreach ($sourceRemovedDefinitionIds as $identifier => $v) {
+        foreach ($sourceRemovedDefinitionIds as $identifier) {
             $this->removedDefinitionIds[$identifier] = true;
             unset($this->definitions[$identifier]);
         }

--- a/tests/ContainerReset/ContainerResetTest.php
+++ b/tests/ContainerReset/ContainerResetTest.php
@@ -79,7 +79,7 @@ class ContainerResetTest extends TestCase
         self::assertFalse($container->has(Bar::class));
 
         self::assertEquals(
-            [__CLASS__ => true, Bar::class => true],
+            [__CLASS__, Bar::class],
             [...$container->getRemovedDefinitionIds()]
         );
 

--- a/tests/DefinitionsLoader/ImportAutoconfigure/ImportAutoconfigureTest.php
+++ b/tests/DefinitionsLoader/ImportAutoconfigure/ImportAutoconfigureTest.php
@@ -90,7 +90,7 @@ class ImportAutoconfigureTest extends TestCase
         ;
 
         self::assertEquals([Fixtures\Person::class, Fixtures\Factories\DiFactoryPerson::class], array_keys([...$loader->definitions()]));
-        self::assertEquals([Fixtures\Foo::class], array_keys([...$loader->removedDefinitionIds()]));
+        self::assertEquals([Fixtures\Foo::class], [...$loader->removedDefinitionIds()]);
     }
 
     public function testConflictAttributeAutowireExcludeAndConfigByDefinition(): void

--- a/tests/DefinitionsLoader/RemovedDefinitions/RemovedDefinitionsTest.php
+++ b/tests/DefinitionsLoader/RemovedDefinitions/RemovedDefinitionsTest.php
@@ -49,7 +49,7 @@ class RemovedDefinitionsTest extends TestCase
                 'Tests\DefinitionsLoader\RemovedDefinitions\Fixtures\Qux\Quux\Baz',
                 'Tests\DefinitionsLoader\RemovedDefinitions\Fixtures\Qux\Bar',
             ],
-            array_keys([...$loader->removedDefinitionIds()])
+            [...$loader->removedDefinitionIds()]
         );
         // available classes
         self::assertSame(

--- a/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
+++ b/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
@@ -78,13 +78,13 @@ class RemovedDefinitionIdsTest extends TestCase
                 useZeroConfigurationDefinition: true,
                 useAttribute: false,
             ),
-            removedDefinitionIds: [Foo::class => true]
+            removedDefinitionIds: [Foo::class]
         );
 
         self::assertTrue($container->has(Bar::class));
         self::assertFalse($container->has(Foo::class));
         self::assertSame(
-            [Foo::class => true],
+            [Foo::class],
             [...$container->getRemovedDefinitionIds()]
         );
     }
@@ -94,7 +94,7 @@ class RemovedDefinitionIdsTest extends TestCase
         $container = new DiContainer(
             new DeferredSourceDefinitionsMutable(
                 static fn () => [],
-                static fn () => [Foo::class => true]
+                static fn () => [Foo::class]
             ),
             config: new DiContainerConfig(
                 useZeroConfigurationDefinition: true,
@@ -103,7 +103,7 @@ class RemovedDefinitionIdsTest extends TestCase
         );
 
         self::assertSame(
-            [Foo::class => true],
+            [Foo::class],
             [...$container->getRemovedDefinitionIds()]
         );
     }
@@ -117,7 +117,7 @@ class RemovedDefinitionIdsTest extends TestCase
                 useZeroConfigurationDefinition: true,
                 useAttribute: false,
             ),
-            removedDefinitionIds: [Foo::class => true]
+            removedDefinitionIds: [Foo::class]
         );
 
         $container->get(Foo::class);
@@ -149,7 +149,6 @@ class RemovedDefinitionIdsTest extends TestCase
             )
             ->build()
         ;
-
         $container->get(Foo::class);
     }
 }

--- a/tests/SourceDefinitionsMutable/DeferredSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/DeferredSourceDefinitionsMutableTest.php
@@ -143,7 +143,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
                 'service.foo' => 'Service foo',
             ],
             static fn () => [
-                'service.foo' => true,
+                'service.foo',
             ]
         );
 
@@ -165,7 +165,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
                 'service.bar' => 'Service bar',
             ],
             static fn () => [
-                'service.foo' => true,
+                'service.foo',
             ]
         );
 
@@ -251,7 +251,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
         self::assertEquals('bin2hex', (string) $s->get('hash.suffix')->getDefinition());
 
-        self::assertEquals(['service.baz', 'service.qux'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz', 'service.qux'], [...$s->getRemovedDefinitionIds()]);
 
         $s->set('service.qux', 'Service qux');
 
@@ -260,7 +260,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
         self::assertCount(4, [...$s->getIterator()]);
 
-        self::assertEquals(['service.baz'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz'], [...$s->getRemovedDefinitionIds()]);
 
         $s->reset();
 
@@ -280,7 +280,7 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
         self::assertEquals('bin2hex', (string) $s->get('hash.suffix')->getDefinition());
 
-        self::assertEquals(['service.baz', 'service.qux'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz', 'service.qux'], [...$s->getRemovedDefinitionIds()]);
     }
 
     public static function dataProviderForReset(): Generator
@@ -301,9 +301,9 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
 
             public static function removed(): Generator
             {
-                yield 'service.baz' => true;
+                yield 'service.baz';
 
-                yield 'service.qux' => true;
+                yield 'service.qux';
             }
         };
 
@@ -325,9 +325,9 @@ class DeferredSourceDefinitionsMutableTest extends TestCase
                 ;
             },
             static function () {
-                yield 'service.baz' => true;
+                yield 'service.baz';
 
-                yield 'service.qux' => true;
+                yield 'service.qux';
             },
         ];
     }
@@ -346,6 +346,6 @@ final class SourceDefinitions
 
     public static function removed(): Generator
     {
-        yield 'baz' => true;
+        yield 'baz';
     }
 }

--- a/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
+++ b/tests/SourceDefinitionsMutable/ImmediateSourceDefinitionsMutableTest.php
@@ -148,7 +148,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
                 'service.foo' => 'Service foo',
             ],
             [
-                'service.foo' => true,
+                'service.foo',
             ]
         );
 
@@ -214,7 +214,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         self::assertFalse($s->has('service.qux'));
         self::assertNull($s->get('service.qux'));
 
-        self::assertEquals(['service.baz', 'service.qux'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz', 'service.qux'], [...$s->getRemovedDefinitionIds()]);
 
         $s->set('service.qux', 'Service qux');
 
@@ -223,7 +223,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
 
         self::assertCount(4, [...$s->getIterator()]);
 
-        self::assertEquals(['service.baz'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz'], [...$s->getRemovedDefinitionIds()]);
 
         $s->reset();
 
@@ -243,7 +243,7 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
         self::assertFalse($s->has('service.qux'));
         self::assertNull($s->get('service.qux'));
 
-        self::assertEquals(['service.baz', 'service.qux'], array_keys([...$s->getRemovedDefinitionIds()]));
+        self::assertEquals(['service.baz', 'service.qux'], [...$s->getRemovedDefinitionIds()]);
     }
 
     public static function dataProviderForReset(): Generator
@@ -256,8 +256,8 @@ class ImmediateSourceDefinitionsMutableTest extends TestCase
                 ->bindArguments('random_string'),
         ];
         $removedIds = [
-            'service.baz' => true,
-            'service.qux' => true,
+            'service.baz',
+            'service.qux',
         ];
 
         yield 'definitions via array' => [


### PR DESCRIPTION
- Resolve #584 

---

> [!WARNING]
> Некоторые изменения в этом коммите ломают обратную совместимость.
>
> - ✅ Для класса `\Kaspi\DiContainer\DiContainerBuilder` изменений не требуется, изменения из этого коммита не затрагивают его.
> - ❌ Для метода класса `\Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable::__construct()` в параметр `$sourceRemovedDefinitionIds` необходимо передавать список идентификаторов `iterable<class-string|non-empty-string>`
> - ❌ Для метода класса `\Kaspi\DiContainer\SourceDefinitions\DeferredSourceDefinitionsMutable::__construct()` в параметр `$sourceRemovedDefinitionIds` необходимо передавать `callable` выражение которое должно возвращать список идентификаторов `null|callable(): iterable<class-string|non-empty-string>`
> - ❌ Для метода класса `\Kaspi\DiContainer\DiContainer::__construct()` в параметр `$removedDefinitionIds` необходимо передавать список идентификаторов `iterable<class-string|non-empty-string>`
> - ❌ Метода класса `\Kaspi\DiContainer\DiContainer::getRemovedDefinitionIds()` возвращает список идентификаторов `iterable<class-string|non-empty-string>`

