### PR TITLE
Tags bounded via `DiRuntime::$tags`

### DIFF
--- a/docs/10-runtime-definition.md
+++ b/docs/10-runtime-definition.md
@@ -21,13 +21,13 @@ use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use function \Kaspi\DiContainer\diRuntime;
 
 diRuntime(
-    string $containerIdentifier,
+    string $containerIdentifierOrClass,
     ?string $message = null,
     ?string $classDefinition = null
 ): DiDefinitionTagArgumentInterface
 ```
 Параметры:
-- `$containerIdentifier` – идентификатора контейнера реализующий сервис, который будет добавлен позже.
+- `$containerIdentifierOrClass` – идентификатора контейнера реализующий сервис или имя класса реализующего сервис, который будет добавлен позже.
 - `$message` – дополнительное информационное сообщение при ошибке.
 - `$classDefinition` – применяется для точного указания PHP класса в определении если необходимо [получать ключ элемента](05-tags.md#ключ-из-метаданных-тега-через-метод-класса) в тегированной коллекции через метод PHP класса или [получать приоритет элемента в тегированной коллекции](05-tags.md#prioritymethod-и-prioritydefaultmethod-для-приоритизации-в-коллекции) через метод PHP класса.
 
@@ -45,7 +45,7 @@ diRuntime(
 > 
 
 > [!NOTE]
-> `$containerIdentifier` может быть представлен любой не пустой строкой
+> `$containerIdentifierOrClass` может быть представлен любой не пустой строкой
 > чтобы сервис можно было получить через метод контейнера `get()`.
 > 
 > Хелпер функция `diRuntime()` не создает конфигурацию экземпляра класса, а только предоставляет идентификатор контейнера.
@@ -59,11 +59,16 @@ diRuntime(
 Применятся к классу для конфигурирования «Runtime definition» в контейнере.
 
 ```php
-#[DiRuntime(string $containerIdentifier = '', ?string $message = null)]
+#[DiRuntime(
+    string $containerIdentifier = '',
+    ?string $message = null,
+    array|\Kaspi\DiContainer\Attributes\Tag|null $tags = null,
+)]
 ```
 Параметры:
 - `$containerIdentifier` – идентификатора контейнера реализующий сервис, который будет добавлен позже.
 - `$message` – дополнительное информационное сообщение при ошибке.
+- `$tags` – указание тегов к конкретному идентификатору контейнера указанному в параметре `$containerIdentifier`.
 
 > [!TIP]
 > Атрибут может быть применен к классу несколько раз с разными значениями параметра `$containerIdentifier`.
@@ -71,6 +76,15 @@ diRuntime(
 
 > [!TIP]
 > Пустая строка в аргументе `$containerIdentifier` будет представлена как полное имя класса – **fully qualified class name** которая является идентификатором контейнера для этого php класса.
+
+> [!NOTE]
+> Значение переданное параметру `$tags` определит как будет сконфигурирован сервис:
+> - значение по умолчанию `null` – конфигурировать через [атрибуты `\Kaspi\DiContainer\Attributes\Tag`](#tag) примененные к текущему классу.
+> - массив из атрибутов `\Kaspi\DiContainer\Attributes\Tag` или одиночный атрибут `\Kaspi\DiContainer\Attributes\Tag` – конфигурировать теги из указанных значений.
+>   - типизация параметра `list<Tag>|Tag`
+> - значение пустой массив (`empty-array` aka `[]`) – не применять никаких тегов к определению.
+>
+
 
 > [!NOTE]
 > [Пример конфигурирования через PHP атрибут](#пример-использования-php-атрибута-diruntime-для-конфигурирования).

--- a/src/DiContainer/Attributes/DiRuntime.php
+++ b/src/DiContainer/Attributes/DiRuntime.php
@@ -11,6 +11,11 @@ final class DiRuntime
 {
     /**
      * @param class-string|string $containerIdentifier
+     * @param null|list<Tag>|Tag  $tags                tags bound to the current `DiRuntime` attribute
      */
-    public function __construct(public readonly string $containerIdentifier = '', public readonly ?string $message = null) {}
+    public function __construct(
+        public readonly string $containerIdentifier = '',
+        public readonly ?string $message = null,
+        public readonly array|Tag|null $tags = null,
+    ) {}
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -143,22 +143,26 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
      */
     private function getDiRuntimeAttributeConfiguringDefinition(ReflectionClass $class): DiRuntime|false
     {
+        $foundDiRuntimeAttribute = false;
+
         if (null === $this->classDefinition) {
+            // We need to ensure that all attributes that have `DiRuntime::$containerIdentifier` are unique.
             foreach (AttributeReader::getDiRuntimeAttribute($class) as $diRuntimeAttribute) {
                 if ('' === $diRuntimeAttribute->containerIdentifier) {
-                    return $diRuntimeAttribute;
+                    $foundDiRuntimeAttribute = $diRuntimeAttribute;
                 }
             }
 
-            return false;
+            return $foundDiRuntimeAttribute;
         }
 
+        // We need to ensure that all attributes that have `DiRuntime::$containerIdentifier` are unique.
         foreach (AttributeReader::getDiRuntimeAttribute($class) as $diRuntimeAttribute) {
             if ($this->containerIdentifierOrClass === $diRuntimeAttribute->containerIdentifier) {
-                return $diRuntimeAttribute;
+                $foundDiRuntimeAttribute = $diRuntimeAttribute;
             }
         }
 
-        return false;
+        return $foundDiRuntimeAttribute;
     }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -34,18 +34,18 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
     private ReflectionClass $classDefinitionReflection;
 
     /**
-     * @param class-string|non-empty-string $containerIdentifier
+     * @param class-string|non-empty-string $containerIdentifierOrClass
      * @param null|class-string             $classDefinition
      */
     public function __construct(
-        private readonly string $containerIdentifier,
+        private readonly string $containerIdentifierOrClass,
         private readonly ?string $message = null,
         private readonly ?string $classDefinition = null,
     ) {}
 
     public function getIdentifier(): string
     {
-        return $this->containerIdentifier;
+        return $this->containerIdentifierOrClass;
     }
 
     public function getMessage(): ?string
@@ -56,11 +56,11 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
     public function resolve(DiContainerInterface $container, mixed $context = null): object
     {
         if (!isset($this->definition)) {
-            $additionalMessage = $this->message ?? sprintf('You should replace the value of definition in the runtime container using the method DiContainerInterface::set(%s, $objectInstance).', var_export($this->containerIdentifier, true));
+            $additionalMessage = $this->message ?? sprintf('You should replace the value of definition in the runtime container using the method DiContainerInterface::set(%s, $objectInstance).', var_export($this->containerIdentifierOrClass, true));
 
             throw new DiDefinitionException(
                 rtrim(
-                    sprintf('The runtime definition with container identifier %s cannot be resolved. %s', var_export($this->containerIdentifier, true), $additionalMessage)
+                    sprintf('The runtime definition with container identifier %s cannot be resolved. %s', var_export($this->containerIdentifierOrClass, true), $additionalMessage)
                 )
             );
         }
@@ -84,7 +84,7 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
             $this->classDefinitionReflection ??= new ReflectionClass($this->getDefinitionIdentifier());
         } catch (ReflectionException $e) {
             throw new DiDefinitionException(
-                sprintf('You should to be defined a php class through the parameters $containerIdentifier or $classDefinition. Current values: $containerIdentifier %s, $classDefinition %s', var_export($this->containerIdentifier, true), var_export($this->classDefinition, true)),
+                sprintf('You should to be defined a php class through the parameters $containerIdentifierOrClass or $classDefinition. Current values: $containerIdentifierOrClass %s, $classDefinition %s', var_export($this->containerIdentifierOrClass, true), var_export($this->classDefinition, true)),
                 previous: $e,
             );
         }
@@ -94,7 +94,7 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
 
     public function getDefinitionIdentifier(): string
     {
-        return $this->classDefinition ?? $this->containerIdentifier; // @phpstan-ignore return.type
+        return $this->classDefinition ?? $this->containerIdentifierOrClass; // @phpstan-ignore return.type
     }
 
     public function reset(): void
@@ -154,7 +154,7 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
         }
 
         foreach (AttributeReader::getDiRuntimeAttribute($class) as $diRuntimeAttribute) {
-            if ($this->containerIdentifier === $diRuntimeAttribute->containerIdentifier) {
+            if ($this->containerIdentifierOrClass === $diRuntimeAttribute->containerIdentifier) {
                 return $diRuntimeAttribute;
             }
         }

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -6,7 +6,9 @@ namespace Kaspi\DiContainer\DiDefinition;
 
 use Generator;
 use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\DiRuntime;
 use Kaspi\DiContainer\Attributes\Tag;
+use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
@@ -109,13 +111,54 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
     {
         try {
             $this->classDefinitionReflection ??= new ReflectionClass($this->getDefinitionIdentifier());
-
-            yield from AttributeReader::getTagAttribute($this->classDefinitionReflection);
-        } catch (ReflectionException $e) {
+            $diRuntimeAttribute = $this->getDiRuntimeAttributeConfiguringDefinition($this->classDefinitionReflection);
+        } catch (AutowireAttributeException|ReflectionException $e) {
             throw new DiDefinitionException(
                 sprintf('Cannot read php attribute "%s" on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
                 previous: $e
             );
         }
+
+        if (false === $diRuntimeAttribute || null === $diRuntimeAttribute->tags) {
+            yield from AttributeReader::getTagAttribute($this->classDefinitionReflection);
+
+            return;
+        }
+
+        if ($diRuntimeAttribute->tags instanceof Tag) {
+            yield $diRuntimeAttribute->tags;
+
+            return;
+        }
+
+        foreach ($diRuntimeAttribute->tags as $argTag) {
+            if ($argTag instanceof Tag) {
+                yield $argTag;
+            }
+        }
+    }
+
+    /**
+     * @throws AutowireAttributeException
+     */
+    private function getDiRuntimeAttributeConfiguringDefinition(ReflectionClass $class): DiRuntime|false
+    {
+        if (null === $this->classDefinition) {
+            foreach (AttributeReader::getDiRuntimeAttribute($class) as $diRuntimeAttribute) {
+                if ('' === $diRuntimeAttribute->containerIdentifier) {
+                    return $diRuntimeAttribute;
+                }
+            }
+
+            return false;
+        }
+
+        foreach (AttributeReader::getDiRuntimeAttribute($class) as $diRuntimeAttribute) {
+            if ($this->containerIdentifier === $diRuntimeAttribute->containerIdentifier) {
+                return $diRuntimeAttribute;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -106,11 +106,11 @@ if (!function_exists('Kaspi\DiContainer\diParameterRuntime')) { // @codeCoverage
 
 if (!function_exists('Kaspi\DiContainer\diRuntime')) { // @codeCoverageIgnore
     /**
-     * @param non-empty-string  $containerIdentifier
-     * @param null|class-string $classDefinition
+     * @param class-string|non-empty-string $containerIdentifierOrClass
+     * @param null|class-string             $classDefinition
      */
-    function diRuntime(string $containerIdentifier, ?string $message = null, ?string $classDefinition = null): DiDefinitionTagArgumentInterface
+    function diRuntime(string $containerIdentifierOrClass, ?string $message = null, ?string $classDefinition = null): DiDefinitionTagArgumentInterface
     {
-        return new DiDefinitionRuntime($containerIdentifier, $message, $classDefinition);
+        return new DiDefinitionRuntime($containerIdentifierOrClass, $message, $classDefinition);
     }
 } // @codeCoverageIgnore

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTaggedTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTaggedTest.php
@@ -31,6 +31,7 @@ class DiDefinitionRuntimeTaggedTest extends TestCase
     #[TestWith(['foo', null])]
     #[TestWith(['service.foo', NonExist::class])]
     #[TestWith([FooFail::class, null])]
+    #[TestWith(['service.foo_fail', FooFail::class])]
     public function testCannotReadTagAttributes(string $id, ?string $classDefinition): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
@@ -100,8 +101,8 @@ class DiDefinitionRuntimeTaggedTest extends TestCase
     }
 }
 
-#[DiRuntime('foo.service')]
-#[DiRuntime('foo.service')]
+#[DiRuntime]
+#[DiRuntime]
 final class FooFail {}
 
 #[DiRuntime]

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTaggedTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTaggedTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionRuntime;
+
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Attributes\AutowireExclude;
+use Kaspi\DiContainer\Attributes\DiRuntime;
+use Kaspi\DiContainer\Attributes\Tag;
+use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Traits\TagsTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(DiContainerConfig::class)]
+#[CoversClass(DiRuntime::class)]
+#[CoversClass(Tag::class)]
+#[CoversClass(TagsTrait::class)]
+class DiDefinitionRuntimeTaggedTest extends TestCase
+{
+    #[TestWith(['foo', null])]
+    #[TestWith(['service.foo', NonExist::class])]
+    #[TestWith([FooFail::class, null])]
+    public function testCannotReadTagAttributes(string $id, ?string $classDefinition): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('Cannot get tags');
+
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(
+                useAttribute: true,
+            ))
+        ;
+
+        $d = new DiDefinitionRuntime($id, classDefinition: $classDefinition);
+        $d->setContainer($mockContainer);
+
+        $d->getTags();
+    }
+
+    #[TestWith([
+        FooSuccess::class,
+        null,
+        [
+            'tags.service_foo' => [
+                'priority' => 100,
+            ],
+        ],
+    ])]
+    #[TestWith([
+        'foo.service_one',
+        FooSuccess::class,
+        [],
+    ])]
+    #[TestWith([
+        'foo.service_two',
+        FooSuccess::class,
+        [
+            'tags.service_foo_two' => [],
+        ],
+    ])]
+    #[TestWith([
+        'foo.service_three',
+        FooSuccess::class,
+        [
+            'tags.service_three.one' => [],
+            'tags.service_three.two' => [
+                'priority' => 100,
+            ],
+        ],
+    ])]
+    #[TestWith([
+        BarSuccess::class,
+        BarSuccess::class,
+        [],
+    ])]
+    public function testReadTagAttributes(string $id, ?string $classDefinition, array $expectTags): void
+    {
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(
+                useAttribute: true,
+            ))
+        ;
+        $d = new DiDefinitionRuntime($id, classDefinition: $classDefinition);
+        $d->setContainer($mockContainer);
+
+        self::assertEquals($expectTags, $d->getTags());
+    }
+}
+
+#[DiRuntime('foo.service')]
+#[DiRuntime('foo.service')]
+final class FooFail {}
+
+#[DiRuntime]
+#[DiRuntime(
+    'foo.service_one',
+    tags: [],
+)]
+#[DiRuntime(
+    'foo.service_two',
+    tags: new Tag('tags.service_foo_two'),
+)]
+#[DiRuntime(
+    'foo.service_three',
+    tags: [
+        new Tag('tags.service_three.one'),
+        new AutowireExclude(),
+        new Tag('tags.service_three.two', priority: 100),
+    ],
+)]
+#[Tag('tags.service_foo', priority: 100)]
+final class FooSuccess {}
+
+#[DiRuntime('bar.service', tags: new Tag('tags.bar_success'))]
+#[DiRuntime(BarSuccess::class, tags: [])]
+#[Tag('tags.bar_success')]
+final class BarSuccess {}

--- a/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
+++ b/tests/DiDefinition/DiDefinitionRuntime/DiDefinitionRuntimeTest.php
@@ -75,7 +75,7 @@ class DiDefinitionRuntimeTest extends TestCase
     public function testIsImplementInterfaceFail(): void
     {
         $this->expectException(DiDefinitionExceptionInterface::class);
-        $this->expectExceptionMessage('You should to be defined a php class through the parameters $containerIdentifier or $classDefinition');
+        $this->expectExceptionMessage('You should to be defined a php class through the parameters $containerIdentifierOrClass or $classDefinition');
 
         (new DiDefinitionRuntime('foo'))->isImplementInterface(FooInterface::class);
     }


### PR DESCRIPTION
- Resolve #612 
---
Новая сигнатура атрибута `\Kaspi\DiContainer\Attributes\DiRuntime`
```php
#[DiRuntime(
    string $containerIdentifier = '',
    ?string $message = null,
    array|\Kaspi\DiContainer\Attributes\Tag|null $tags = null,
)]
```
> [!IMPORTANT]
> Атрибут `\Kaspi\DiContainer\Attributes\DiRuntime` будет предоставлять новый параметр:
- `$tags`:
  - значение по умолчанию `null` – конфигурировать через атрибуты `Tag` примененные к текущему классу.
  - значение `array<Tag>` или `Tag` – конфигурировать теги из указанных значений.
  - значение `empty-array` aka `[]` – не применять никаких тегов к определению.
