### PR TITLE
Checks parameter `Autowire::$id` is unique for all attributes.

### DIFF
--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -13,6 +13,7 @@ use Kaspi\DiContainer\Attributes\Tag;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\Enum\SetupConfigureMethod;
+use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
@@ -269,14 +270,13 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
     {
         try {
             $reflectionClass = $this->getDefinition();
-        } catch (DiDefinitionException $e) {
+            $autowireAttribute = $this->getAutowireAttributeConfiguringDefinition($reflectionClass);
+        } catch (AutowireAttributeException|DiDefinitionException $e) {
             throw new DiDefinitionException(
                 sprintf('Cannot read php attribute "%s" on class "%s".', Tag::class, $this->getDefinitionIdentifier()),
                 previous: $e
             );
         }
-
-        $autowireAttribute = $this->getAutowireAttributeConfiguringDefinition($reflectionClass);
 
         if (false === $autowireAttribute || null === $autowireAttribute->tags) {
             yield from AttributeReader::getTagAttribute($reflectionClass);
@@ -321,6 +321,8 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
 
     /**
      * @return Generator<Setup|SetupImmutable>
+     *
+     * @throws AutowireAttributeException
      */
     private function getSetupAttributes(ReflectionClass $class): Generator
     {
@@ -349,25 +351,32 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
         }
     }
 
+    /**
+     * @throws AutowireAttributeException
+     */
     private function getAutowireAttributeConfiguringDefinition(ReflectionClass $class): Autowire|false
     {
+        $foundAttribute = false;
+
         if (null === $this->getContainerIdentifier()) {
+            // We need to ensure that all attributes that have `Autowire::$id` are unique.
             foreach (AttributeReader::getAutowireAttribute($class) as $attribute) {
                 if ('' === $attribute->id) {
-                    return $attribute;
+                    $foundAttribute = $attribute;
                 }
             }
 
-            return false;
+            return $foundAttribute;
         }
 
+        // We need to ensure that all attributes that have `Autowire::$id` are unique.
         foreach (AttributeReader::getAutowireAttribute($class) as $attribute) {
             if ($this->getContainerIdentifier() === $attribute->id) {
-                return $attribute;
+                $foundAttribute = $attribute;
             }
         }
 
-        return false;
+        return $foundAttribute;
     }
 
     /**

--- a/tests/DiDefinition/DiDefinitionAutowire/Fixtures/FooConfigureAutowireAttr.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/Fixtures/FooConfigureAutowireAttr.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DiDefinition\DiDefinitionAutowire\Fixtures;
+
+use Kaspi\DiContainer\Attributes\Autowire;
+use Kaspi\DiContainer\Attributes\Tag;
+
+#[Autowire(tags: new Tag('tags.one'))]
+#[Autowire(tags: new Tag('tags.two'))]
+final class FooConfigureAutowireAttr {}

--- a/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
+++ b/tests/DiDefinition/DiDefinitionAutowire/TagTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
+use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\FooConfigureAutowireAttr;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\FooMultiConfigSetup;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagOne;
 use Tests\DiDefinition\DiDefinitionAutowire\Fixtures\TaggedClassBindTagTwo;
@@ -385,5 +386,22 @@ class TagTest extends TestCase
         self::assertCount(2, $definition->getTags());
         self::assertTrue($definition->hasTag('tags.baz'));
         self::assertTrue($definition->hasTag('tags.qux'));
+    }
+
+    public function testUniqueIdParameterInAutowireAttr(): void
+    {
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessage('Cannot get tags on class');
+
+        $mockContainer = $this->createMock(DiContainerInterface::class);
+        $mockContainer->method('getConfig')
+            ->willReturn(new DiContainerConfig(useAttribute: true))
+        ;
+
+        $definition = (new DiDefinitionAutowire(FooConfigureAutowireAttr::class))
+            ->setContainer($mockContainer)
+        ;
+
+        $definition->getTags();
     }
 }


### PR DESCRIPTION
- Resolve #617 