### PR TITLE
Custom container dependency reset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ var_dump($container->get(TestClass::class)->container instanceof ContainerInterf
 * 📋 [Параметры контейнера](https://github.com/agdobrynin/di-container/blob/main/docs/09-container-parameters.md).
 * 🗳️ [Внедрение экземпляра класса в рантайм контейнер](https://github.com/agdobrynin/di-container/blob/main/docs/10-runtime-definition.md).
 * 🧹 [Сброс контейнера зависимостей](https://github.com/agdobrynin/di-container/blob/main/docs/11-container-reset.md).
+* ♻️ [Сброс состояния объектов для долго-живущих процессов](https://github.com/agdobrynin/di-container/blob/main/docs/12-object-resetters.md).
 
 ## Тесты
 Запуск тестов без подсчёта покрытия кода

--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ $container->call(
 Для определений контейнера у которых неуказан способ получения через метод контейнера `get()`
 применяется значение по умолчанию из конфигурации.
 
+#### Конфигурировать сервис сброса состояния объектов из определений контейнера:
+```php
+\Kaspi\DiContainer\Interfaces\DiContainerConfigInterface::isConfigureObjectResettersFromDefinitions(): bool;
+```
+В долгоживущих процессах некоторые сервисы контейнера могут требовать сброса своего состояния.
+Для сброса состояния таких сервисов может быть использован механизм автоматического конфигурирования
+сервиса на основе конфигурации определений контейнера. Подробности в разделе [«Сброс состояния объектов для долго-живущих процессов».](https://github.com/agdobrynin/di-container/blob/main/docs/12-object-resetters.md)
+
 **Пример конфигурации:**
 ```php
 use Kaspi\DiContainer\{DiContainerConfig, DiContainerBuilder};
@@ -177,6 +185,7 @@ $diConfig = new DiContainerConfig(
     useZeroConfigurationDefinition: false,
     useAttribute: false,
     isSingletonServiceDefault: true,
+    isConfigureObjectResettersFromDefinitions: false,
 );
 
 // передать настройки в построитель контейнера

--- a/docs/01-php-definition.md
+++ b/docs/01-php-definition.md
@@ -106,10 +106,13 @@ var_dump(
 Автоматическое создание объекта и внедрения зависимостей.
 
 ```php
-use \Kaspi\DiContainer\Interfaces\DiDefinition\{DiDefinitionSetupAutowireInterface, DiDefinitionTagArgumentInterface};
+use \Kaspi\DiContainer\Interfaces\DiDefinition\{DiDefinitionSetupAutowireInterface, DiDefinitionTagArgumentInterface, DiDefinitionResetterSetterInterface};
 use function \Kaspi\DiContainer\diAutowire;
 
-diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionSetupAutowireInterface & DiDefinitionTagArgumentInterface
+diAutowire(
+    string $definition,
+    ?bool $isSingleton = null
+): DiDefinitionSetupAutowireInterface & DiDefinitionTagArgumentInterface & DiDefinitionResetterSetterInterface
 ```
 Параметры:
 - `$definition` – имя класса с пространством имен представленный строкой. Можно использовать безопасное объявление через магическую константу `::class` - `MyClass::class`
@@ -117,15 +120,17 @@ diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionSetupAuto
 
 > [!IMPORTANT]
 > Функция `diAutowire` возвращает объект реализующий интерфейсы
-> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface`
-> и `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface`.
+> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface`, 
+> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface`, 
+> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface`.
 > 
 > Интерфейсы представляют методы:
 >   - `bindArguments` - аргументы для конструктора класса
 >   - `setup` - вызов метода класса с параметрами (_mutable setter method_) для настройки класса
 >   - `setupImmutable` - вызов метода класса с параметрами (_immutable setter method_) и возвращаемым значением
 >   - `bindTag` - добавляет тег с мета-данными для определения
- 
+>   - `setResetter` - конфигурация сброса состояния объекта.
+
 **Аргументы для конструктора:**
 ```php
 bindArguments(mixed ...$argument)
@@ -234,6 +239,13 @@ bindTag(string $name, array $options = [], null|int|string $priority = null)
 ```
 > [!TIP]
 > Более подробное [описание работы с тегами](05-tags.md).
+
+**Конфигурация сброса состояния объекта:**
+```php
+setResetter(callable|string $resetter)
+```
+
+> Более подробное [описание конфигурации для сброса состояния объекта](12-object-resetters.md).
 
 ##### Идентификатор контейнера для diAutowire.
 При конфигурировании идентификатор контейнера может быть сформирован на основе FQCN  (**Fully Qualified Class Name**)

--- a/docs/10-runtime-definition.md
+++ b/docs/10-runtime-definition.md
@@ -17,14 +17,14 @@
 Хелпер функция для конфигурационных файлов.
 
 ```php
-use \Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
+use \Kaspi\DiContainer\Interfaces\DiDefinition\{DiDefinitionTagArgumentInterface, DiDefinitionResetterSetterInterface};
 use function \Kaspi\DiContainer\diRuntime;
 
 diRuntime(
     string $containerIdentifierOrClass,
     ?string $message = null,
     ?string $classDefinition = null
-): DiDefinitionTagArgumentInterface
+): DiDefinitionTagArgumentInterface & DiDefinitionResetterSetterInterface
 ```
 Параметры:
 - `$containerIdentifierOrClass` – идентификатора контейнера реализующий сервис или имя класса реализующего сервис, который будет добавлен позже.
@@ -32,11 +32,14 @@ diRuntime(
 - `$classDefinition` – применяется для точного указания PHP класса в определении если необходимо [получать ключ элемента](05-tags.md#ключ-из-метаданных-тега-через-метод-класса) в тегированной коллекции через метод PHP класса или [получать приоритет элемента в тегированной коллекции](05-tags.md#prioritymethod-и-prioritydefaultmethod-для-приоритизации-в-коллекции) через метод PHP класса.
 
 > [!IMPORTANT]
-> Функция `diRuntime` возвращает объект реализующий интерфейс
-> `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface`.
+> Функция `diRuntime` возвращает объект реализующий интерфейсы:
+> - `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface`, 
+> - `\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface`.
+
 >
-> Интерфейс представляет методы:
->   - `bindTag` - добавляет тег с мета-данными для определения
+> Методы доступные при вызове хелпер функции:
+>   - `bindTag` - добавляет тег с мета-данными для определения.
+>   - `setResetter` - [конфигурация сброса состояния объекта](12-object-resetters.md).
 >
 > [Пример использования тегов](#пример-тегирования-runtime-definition).
 

--- a/docs/12-object-resetters.md
+++ b/docs/12-object-resetters.md
@@ -1,0 +1,282 @@
+# ♻️ Сброс состояния объектов для долго-живущих процессов.
+
+Некоторые сервисы которые разрешаются через метод контейнера `get(string $id)` и возвращают один и тот же объект (_php класс_),
+т.е. сохраняя своё состояние в рамках всех вызовов контейнера, могут требовать сброса своего состояния в долгоживущих процессах.
+
+Пример класса который может «накапливать данные»:
+```php
+declare(strict_types=1);
+
+namespace  App\Services;
+
+final class FooLogger
+{
+    private array $logs = [];
+
+    // other methods
+
+    public function log(string $where, string $message): void
+    {
+        $this->logs[] = [
+            'where' => $where,
+            'message' => $message,
+        ];
+    }
+    
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+}
+```
+Конфигурация для сервиса `App\Services\FooLogger` с указанием параметра `$isSingleton = true`:
+```php
+// /app/src/config/services_foo_logger.php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use Generator;
+use App\Services\FooLogger;
+
+use function Kaspi\DiContainer\diAutowire;
+
+return static function (DefinitionsConfiguratorInterface $configurator): Generator {
+    // `$container->get(\App\Services\FooLogger::class)` всегда возвращать один и тот же объект
+    yield diAutowire(FooLogger::class, isSingleton: true);
+};
+```
+Приложение работающее по схеме «event loop»:
+```php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Framework\AppFactory;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', '/app/src')
+    ->load('/app/src/config/services_foo_logger.php')
+    ->build();
+
+$app = AppFactory::create(
+    // ... some dependency here
+    container: $container;
+);
+
+// Event loop
+while ($request = $app->getRequest()) {
+    $response = $app->handle($request);
+    $app->emit($response);
+}
+```
+получая объект через `$container->get(\App\Services\FooLogger::class)` внутри приложения будет получен один и тот-же объект.
+Так как разные компоненты приложения могут получать зависимость и вызывать метод `\App\Services\FooLogger::log()`,
+то это приведет к «накоплению данных» в свойстве класса `\App\Services\FooLogger::$logs`.
+Чтобы избежать утечек памяти, нужно использовать механизм сброса состояния объекта.
+
+## Поддерживаемые значения конфигурации сброса состояния объекта.
+Конфигурация представлена как идентификатор контейнера для сервиса получаемого через метод контейнера `get(string $id)` и значение которое будет вызвано для сброса состояния полученного объекта.
+
+Типы значений:
+- `callable(object $object): void` – вызываемое выражение с параметром типа `object` которое будет получено через метод контейнера `get(string $id)`.
+- `non-empty-string` – имя публичного метода PHP класса которое будет получено через метод контейнера `get(string $id)`.
+
+
+> [!TIP]
+> Вызываемый тип `callable` для сброса состояния объекта так же может быть представлен классом со статическим методом или обычной функцией.
+> ```php
+> $resetter = [App\Qux::class, 'doReset'];
+> ```
+> ```php
+> $resetter = 'App\functions\reset_bar_function';
+> ```
+>
+
+### Автоматическое конфигурирование сервиса сброса состояния объектов на основе установленных значений в определения контейнера.
+Определения контейнера поддерживающие конфигурирование сброса состояния объекта реализуют интерфейс
+`\Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface`.
+
+Метод конфигурирования:
+```php
+setResetter(callable|string $resetter)
+``` 
+Параметры:
+- `$resetter` – конфигурация сброса состояния объекта.
+
+Параметр `$resetter` должен иметь сигнатуру `callable(object $object): void | non-empty-string`.
+
+Метод `setResetter()` применим к хелпер функциям:
+- [diAutowire](01-php-definition.md#diautowire).
+- [diRuntime](10-runtime-definition.md#хелпер-функция-diruntime).
+
+**Пример конфигурирования сброса состояния объекта через определение контейнера**:
+```php
+declare(strict_types=1);
+
+// /app/src/Services/Foo.php
+namespace App\Services;
+
+final class Foo {
+    // other method here
+
+    public function doReset(): void {
+        // reset state here
+    }
+}
+```
+```php
+declare(strict_types=1);
+
+// /app/src/Services/Bar.php
+namespace App\Services;
+
+final class Bar {
+    // other method here
+    
+    public function doResetLogs(): void {
+        // reset state here
+    }
+    
+    public function doResetBaz(): void {
+        // reset state here
+    }
+}
+```
+```php
+// /app/src/config/services_with_resetters.php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use Generator;
+use App\Services\{Foo, Bar};
+
+use function Kaspi\DiContainer\diAutowire;
+
+return static function (DefinitionsConfiguratorInterface $configurator): Generator {
+    yield diAutowire(Foo::class, isSingleton: true)
+        // Для сброса вызвать метод класса Foo::doReset()
+        ->setResetter('doReset');
+    
+    yield diAutowire(Bar::class, isSingleton: true)
+        // Для сброса вызвать callback функцию
+        ->setResetter(static function (Bar $bar): void {
+            $bar->doResetLogs();
+            $bar->doResetBaz();
+        });
+};
+```
+> [!TIP]
+> В составе библиотеки уже реализован PHP класс `\Kaspi\DiContainer\ObjectResetters`,
+> который будет настраивать сброс состояния объектов из определений контейнера и выполнять их:
+> 
+```php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\ObjectResetters;
+use Framework\AppFactory;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', '/app/src')
+    ->load('/app/src/config/services.php')
+    ->load('/app/src/config/services_with_resetters.php')
+    ->build();
+
+$app = AppFactory::create(
+    // ... some dependency here
+    container: $container;
+);
+
+// получение настроенного PHP класса для сброса состояния объектов
+$resetters = $container->get(ObjectResetters::class);
+
+// Event loop
+while ($request = $app->getRequest()) {
+    $response = $app->handle($request);
+    $app->emit($response);
+    // сбросить состояние объектов.
+    $resetters->reset();
+}
+```
+> [!IMPORTANT]
+> Для автоматической конфигурации сброса состояния объектов необходимо
+> чтобы параметр `\Kaspi\DiContainer\DiContainerConfig::$isConfigureObjectResettersFromDefinitions` имел значение `true`.
+>
+
+> [!TIP]
+> Если PHP класс реализует интерфейс `\Kaspi\DiContainer\Interfaces\ResetInterface`,
+> то контейнер автоматически сконфигурирует определение для сброса состояния через метод класса `reset()`.
+> ```php
+>   final class Foo implements \Kaspi\DiContainer\Interfaces\ResetInterface
+>   {
+>       public function reset() : void {
+>            // TODO: Implement reset() method.
+>       }
+>   }
+> ```
+> будет автоматически сконфигурирован метод `setResetter('reset')`.
+
+### Ручная настройка сервиса сброса состояния объектов.
+
+Для настройки следует использовать [хелпер функцию `diAutowire`](01-php-definition.md#diautowire):
+```php
+// /app/src/config/object_resetters.php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
+use Kaspi\DiContainer\ObjectResetters;
+use Generator;
+use App\Services\{Foo, Bar};
+
+use function Kaspi\DiContainer\diAutowire;
+
+return static function (DefinitionsConfiguratorInterface $configurator): Generator {
+    // Ключ массива это идентификатор контейнера для получения объекта
+    // которому необходимо сбросить состояние, а значение это конфигурация для сброса объекта.
+    $resettersConfiguration = [
+        // Для сброса вызвать метод класса Foo::doReset()
+        Foo::class => 'doReset',
+        // Для сброса вызвать callback функцию
+        Bar::class => static function (Bar $bar): void {
+            $bar->doResetLogs();
+            $bar->doResetBaz();
+        },
+    ];
+
+    // `$container->get(\Kaspi\DiContainer\ObjectResetters::class)` всегда возвращать один и тот же объект
+    yield diAutowire(ObjectResetters::class, isSingleton: true)
+        // передать настройку через сеттер-метод `ObjectResetters::setup()`
+        ->setup('setup', arguments: [$resettersConfiguration]);
+};
+```
+```php
+declare(strict_types=1);
+
+use Kaspi\DiContainer\DiContainerBuilder;
+use Kaspi\DiContainer\ObjectResetters;
+use Framework\AppFactory;
+
+$container = (new DiContainerBuilder())
+    ->import('App\\', '/app/src')
+    ->load('/app/src/config/object_resetters.php')
+    ->build();
+
+$app = AppFactory::create(
+    // ... some dependency here
+    container: $container;
+);
+
+// получение настроенного сервиса для сброса состояния объектов
+$resetters = $container->get(ObjectResetters::class);
+
+// Event loop
+while ($request = $app->getRequest()) {
+    $response = $app->handle($request);
+    $app->emit($response);
+    // сбросить состояние объектов.
+    $resetters->reset();
+}
+```
+> [!IMPORTANT]
+> Ручная настройка сброса состояния объектов **отключает**
+> [автоматическое конфигурирование из определений контейнера](#автоматическое-конфигурирование-сервиса-сброса-состояния-объектов-на-основе-установленных-значений-в-определения-контейнера).
+>

--- a/src/DiContainer/Compiler/CompilableDefinition/ObjectEntry.php
+++ b/src/DiContainer/Compiler/CompilableDefinition/ObjectEntry.php
@@ -156,7 +156,7 @@ final class ObjectEntry implements CompilableDefinitionInterface
                     $codeResetters .= ",\n";
                 }
 
-                $codeResetters .= "]\n";
+                $codeResetters .= ']';
 
                 $serviceSetupStatement = sprintf('%s->%s(%s)', $serviceVar, $methodName, $codeResetters);
                 $objectCompiledEntry->addToStatements($serviceSetupStatement);

--- a/src/DiContainer/Compiler/CompilableDefinition/ObjectEntry.php
+++ b/src/DiContainer/Compiler/CompilableDefinition/ObjectEntry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Compiler\CompilableDefinition;
 
+use Closure;
 use Kaspi\DiContainer\Compiler\CompiledEntry;
 use Kaspi\DiContainer\Compiler\Helper;
 use Kaspi\DiContainer\Enum\SetupConfigureMethod;
@@ -18,8 +19,16 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\Arguments\ArgumentBuilderInterface
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ArgumentBuilderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 
+use function get_debug_type;
+use function is_array;
+use function is_iterable;
+use function is_string;
+use function reset;
 use function sprintf;
+use function str_starts_with;
+use function var_export;
 
 final class ObjectEntry implements CompilableDefinitionInterface
 {
@@ -108,6 +117,53 @@ final class ObjectEntry implements CompilableDefinitionInterface
 
         $objectCreateStatement = sprintf('%s = %s', $objectCompiledEntry->getScopeServiceVar(), $compiledObjectConstructor);
         $objectCompiledEntry->addToStatements($objectCreateStatement);
+
+        if ($this->definition->getDefinition()->implementsInterface(ObjectResettersInterface::class)) {
+            /**
+             * @var ArgumentBuilderInterface $setupArgBuilder
+             */
+            foreach ($setupArgBuilders as [, $setupArgBuilder]) {
+                $setupArgs = $setupArgBuilder->buildByPriorityBindArguments();
+                $argumentResetters = reset($setupArgs);
+
+                if (!is_iterable($argumentResetters)) {
+                    throw new DefinitionCompileException(
+                        sprintf('The first argument for %s should be `iterable` type. Got argument type `%s`.', CommonHelper::functionName($setupArgBuilder->getFunctionOrMethod()), get_debug_type($argumentResetters))
+                    );
+                }
+
+                $methodName = $setupArgBuilder->getFunctionOrMethod()->name;
+                $serviceVar = $objectCompiledEntry->getScopeServiceVar();
+
+                $codeResetters = "[\n";
+
+                foreach ($argumentResetters as $entryId => $resetter) {
+                    $codeResetters .= sprintf('  %s => ', var_export($entryId, true));
+
+                    if ($resetter instanceof Closure) {
+                        $codeResetters .= $this->transformer->getClosureParser()->getCode($resetter);
+                    } elseif (is_array($resetter) && is_string($resetter[0])) {
+                        $class = str_starts_with($resetter[0], '\\') ? $resetter[0] : '\\'.$resetter[0];
+                        $codeResetters .= sprintf('[%s, %s]', var_export($class, true), var_export($resetter[1], true));
+                    } elseif (is_string($resetter)) {
+                        $codeResetters .= sprintf('%s', var_export($resetter, true));
+                    } else {
+                        throw new DefinitionCompileException(
+                            sprintf('The resetter for container identifier %s type should be is `callable` or `string`. Got type `%s`.', var_export($entryId, true), get_debug_type($resetter))
+                        );
+                    }
+
+                    $codeResetters .= ",\n";
+                }
+
+                $codeResetters .= "]\n";
+
+                $serviceSetupStatement = sprintf('%s->%s(%s)', $serviceVar, $methodName, $codeResetters);
+                $objectCompiledEntry->addToStatements($serviceSetupStatement);
+            }
+
+            return $objectCompiledEntry->setExpression($objectCompiledEntry->getScopeServiceVar());
+        }
 
         /**
          * @var ArgumentBuilderInterface $setupArgBuilder

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -58,7 +58,7 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
 
                 public function isConfigureObjectResettersFromDefinitions(): bool
                 {
-                    return <?php echo \var_export($config->isConfigureObjectResettersFromDefinitions(), true); ?>;
+                    return false;
                 }
             },
 <?php if ($container->getRemovedDefinitionIds()->valid()) { ?>

--- a/src/DiContainer/Compiler/template.php
+++ b/src/DiContainer/Compiler/template.php
@@ -55,6 +55,11 @@ final class <?php echo $containerFQN->getClass(); ?> extends \Kaspi\DiContainer\
                 {
                     return <?php echo \var_export($config->isUseAttribute(), true); ?>;
                 }
+
+                public function isConfigureObjectResettersFromDefinitions(): bool
+                {
+                    return <?php echo \var_export($config->isConfigureObjectResettersFromDefinitions(), true); ?>;
+                }
             },
 <?php if ($container->getRemovedDefinitionIds()->valid()) { ?>
             removedDefinitionIds: (static function (): \Generator {

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -24,6 +24,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionLinkInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSingletonInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTaggedAsInterface;
@@ -32,6 +33,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierAlreadyRegisteredExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ContainerIdentifierExceptionInterface;
+use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 use Kaspi\DiContainer\Interfaces\ResetInterface;
 use Kaspi\DiContainer\Interfaces\SourceDefinitionsMutableInterface;
 use Kaspi\DiContainer\Interfaces\SourceParametersMutableInterface;
@@ -135,7 +137,9 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         return $this->definitions->has($id)
             || array_key_exists($id, $this->resolved)
             || isset($this->containerIds[$id])
-            || $this->hasViaZeroConfigurationDefinition($id);
+            || $this->hasViaZeroConfigurationDefinition($id)
+            || ObjectResetters::class === $id
+            || ObjectResettersInterface::class === $id;
     }
 
     public function set(string $id, mixed $definition): static
@@ -325,6 +329,23 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
         if (isset($this->diResolvedDefinition[$id])) {
             return $this->diResolvedDefinition[$id];
+        }
+
+        if (ObjectResetters::class === $id || ObjectResettersInterface::class === $id) {
+            $objectResetters = new DiDefinitionAutowire(ObjectResetters::class, true);
+            $resetters = [];
+
+            foreach ($this->definitions->getIterator() as $entryId => $definition) {
+                if ($definition instanceof DiDefinitionResetterInterface
+                    && false !== ($definitionResetter = $definition->getResetter())) {
+                    $resetters[$entryId] = $definitionResetter;
+                }
+            }
+
+            $objectResetters->setup('setup', [$resetters]);
+            $this->definitions->set($id, $objectResetters);
+
+            return $this->diResolvedDefinition[$id] = $objectResetters;
         }
 
         try {

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -137,8 +137,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         return $this->definitions->has($id)
             || array_key_exists($id, $this->resolved)
             || isset($this->containerIds[$id])
-            || $this->hasViaZeroConfigurationDefinition($id)
-            || ObjectResettersInterface::class === $id;
+            || $this->hasViaZeroConfigurationDefinition($id);
     }
 
     public function set(string $id, mixed $definition): static
@@ -201,7 +200,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     public function getDefinitions(): iterable
     {
-        $needAutoconfigureObjectRestters = true;
+        $needAutoconfigureObjectRestters = $this->config->isConfigureObjectResettersFromDefinitions();
 
         foreach ($this->definitions->getIterator() as $id => $definition) {
             if (!isset($this->containerIds[$id])) {
@@ -340,7 +339,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             return $this->diResolvedDefinition[$id];
         }
 
-        if (ObjectResettersInterface::class === $id) {
+        if ($this->config->isConfigureObjectResettersFromDefinitions() && ObjectResettersInterface::class === $id) {
             $resetter = $this->autoconfigureObjectResettersDefinition();
             $this->definitions->set($id, $resetter);
 
@@ -423,6 +422,10 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
     protected function hasViaZeroConfigurationDefinition(string $id): bool
     {
+        if (ObjectResettersInterface::class === $id) {
+            return $this->config->isConfigureObjectResettersFromDefinitions();
+        }
+
         if (!$this->config->isUseZeroConfigurationDefinition()) {
             return false;
         }

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -7,6 +7,7 @@ namespace Kaspi\DiContainer;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireException;
@@ -337,20 +338,10 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         }
 
         if (isset($this->objectResetterIds[$id])) {
-            $objectResetters = new DiDefinitionAutowire(ObjectResetters::class, true);
-            $resetters = [];
+            $resetter = $this->autoconfigureObjectResettersDefinition();
+            $this->definitions->set($id, $resetter);
 
-            foreach ($this->definitions->getIterator() as $entryId => $definition) {
-                if ($definition instanceof DiDefinitionResetterInterface
-                    && false !== ($definitionResetter = $definition->getResetter())) {
-                    $resetters[$entryId] = $definitionResetter;
-                }
-            }
-
-            $objectResetters->setup('setup', [$resetters]);
-            $this->definitions->set($id, $objectResetters);
-
-            return $this->diResolvedDefinition[$id] = $objectResetters;
+            return $this->diResolvedDefinition[$id] = $resetter;
         }
 
         try {
@@ -454,6 +445,23 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         if (array_key_exists($id, $this->circularCallWatcher)) {
             throw new CallCircularDependencyException(callIds: [...array_keys($this->circularCallWatcher), $id]);
         }
+    }
+
+    protected function autoconfigureObjectResettersDefinition(): DiDefinitionCallable
+    {
+        $resetters = [];
+
+        foreach ($this->definitions as $entryId => $definition) {
+            if ($definition instanceof DiDefinitionResetterInterface
+                && false !== ($definitionResetter = $definition->getResetter())) {
+                $resetters[$entryId] = $definitionResetter;
+            }
+        }
+
+        return new DiDefinitionCallable(
+            definition: static fn (ContainerInterface $container) => (new ObjectResetters($container))->setup($resetters),
+            isSingleton: true
+        );
     }
 
     private function getDiDefinitionWrapper(DiDefinitionAutowireInterface|DiDefinitionInterface $definition, ?bool $singleton): DiDefinitionSingletonInterface

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -103,11 +103,6 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     protected readonly array $containerIds;
 
     /**
-     * @var array<class-string, true>
-     */
-    protected readonly array $objectResetterIds;
-
-    /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
      * @param iterable<class-string|non-empty-string>                                            $removedDefinitionIds
      * @param iterable<non-empty-string, SourceParameterType>|SourceParametersMutableInterface   $parameters
@@ -128,7 +123,6 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             ? new ImmediateSourceParameters($parameters)
             : $parameters;
         $this->containerIds = [ContainerInterface::class => true, DiContainerInterface::class => true, __CLASS__ => true];
-        $this->objectResetterIds = [ObjectResetters::class => true, ObjectResettersInterface::class => true];
     }
 
     public function get(string $id): mixed
@@ -144,12 +138,12 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             || array_key_exists($id, $this->resolved)
             || isset($this->containerIds[$id])
             || $this->hasViaZeroConfigurationDefinition($id)
-            || array_key_exists($id, $this->objectResetterIds);
+            || ObjectResettersInterface::class === $id;
     }
 
     public function set(string $id, mixed $definition): static
     {
-        if (isset($this->containerIds[$id]) || isset($this->objectResetterIds[$id])) {
+        if (isset($this->containerIds[$id]) || ObjectResettersInterface::class === $id) {
             throw new ContainerIdentifierAlreadyRegisteredException(id: $id);
         }
 
@@ -336,7 +330,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             return $this->diResolvedDefinition[$id];
         }
 
-        if (isset($this->objectResetterIds[$id])) {
+        if (ObjectResettersInterface::class === $id) {
             $resetter = $this->autoconfigureObjectResettersDefinition();
             $this->definitions->set($id, $resetter);
 

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -201,10 +201,20 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     public function getDefinitions(): iterable
     {
+        $needAutoconfigureObjectRestters = true;
+
         foreach ($this->definitions->getIterator() as $id => $definition) {
             if (!isset($this->containerIds[$id])) {
                 yield $id => $definition;
             }
+
+            if ($needAutoconfigureObjectRestters && ObjectResettersInterface::class === $id) {
+                $needAutoconfigureObjectRestters = false;
+            }
+        }
+
+        if ($needAutoconfigureObjectRestters) {
+            yield ObjectResettersInterface::class => $this->autoconfigureObjectResettersDefinition();
         }
     }
 

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -7,7 +7,6 @@ namespace Kaspi\DiContainer;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
-use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionFactory;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\Exception\AutowireException;
@@ -447,7 +446,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         }
     }
 
-    protected function autoconfigureObjectResettersDefinition(): DiDefinitionCallable
+    protected function autoconfigureObjectResettersDefinition(): DiDefinitionAutowire
     {
         $resetters = [];
 
@@ -458,10 +457,9 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             }
         }
 
-        return new DiDefinitionCallable(
-            definition: static fn (ContainerInterface $container) => (new ObjectResetters($container))->setup($resetters),
-            isSingleton: true
-        );
+        return (new DiDefinitionAutowire(ObjectResetters::class, true))
+            ->setup('setup', [$resetters])
+        ;
     }
 
     private function getDiDefinitionWrapper(DiDefinitionAutowireInterface|DiDefinitionInterface $definition, ?bool $singleton): DiDefinitionSingletonInterface

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -213,10 +213,20 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
         }
 
         if ($this->config->isConfigureObjectResettersFromDefinitions()) {
+            $needAutoconfigureObjectResetters = true;
+
             foreach ($this->objectResettersIds as $id => $v) {
-                if (!$this->definitions->has($id)) {
-                    yield $id => $this->autoconfigureObjectResettersDefinition();
+                if ($this->definitions->has($id)) {
+                    $needAutoconfigureObjectResetters = false;
+
+                    break;
                 }
+            }
+
+            if ($needAutoconfigureObjectResetters) {
+                $diDefinitionAutowireObjectResetters = $this->autoconfigureObjectResettersDefinition();
+
+                yield $diDefinitionAutowireObjectResetters->getIdentifier() => $diDefinitionAutowireObjectResetters;
             }
         }
     }
@@ -343,7 +353,13 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             return $this->diResolvedDefinition[$id];
         }
 
-        if ($this->config->isConfigureObjectResettersFromDefinitions() && isset($this->objectResettersIds[$id])) {
+        if (isset($this->objectResettersIds[$id]) && $this->config->isConfigureObjectResettersFromDefinitions()) {
+            foreach ($this->objectResettersIds as $entryId => $v) {
+                if (isset($this->diResolvedDefinition[$entryId])) {
+                    return $this->diResolvedDefinition[$id] = $this->diResolvedDefinition[$entryId];
+                }
+            }
+
             $resetter = $this->autoconfigureObjectResettersDefinition();
             $this->definitions->set($id, $resetter);
 

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -103,6 +103,11 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     protected readonly array $containerIds;
 
     /**
+     * @var array<class-string, true>
+     */
+    protected readonly array $objectResetterIds;
+
+    /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
      * @param iterable<class-string|non-empty-string>                                            $removedDefinitionIds
      * @param iterable<non-empty-string, SourceParameterType>|SourceParametersMutableInterface   $parameters
@@ -123,6 +128,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             ? new ImmediateSourceParameters($parameters)
             : $parameters;
         $this->containerIds = [ContainerInterface::class => true, DiContainerInterface::class => true, __CLASS__ => true];
+        $this->objectResetterIds = [ObjectResetters::class => true, ObjectResettersInterface::class => true];
     }
 
     public function get(string $id): mixed
@@ -138,13 +144,12 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             || array_key_exists($id, $this->resolved)
             || isset($this->containerIds[$id])
             || $this->hasViaZeroConfigurationDefinition($id)
-            || ObjectResetters::class === $id
-            || ObjectResettersInterface::class === $id;
+            || array_key_exists($id, $this->objectResetterIds);
     }
 
     public function set(string $id, mixed $definition): static
     {
-        if (isset($this->containerIds[$id])) {
+        if (isset($this->containerIds[$id]) || isset($this->objectResetterIds[$id])) {
             throw new ContainerIdentifierAlreadyRegisteredException(id: $id);
         }
 
@@ -331,7 +336,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             return $this->diResolvedDefinition[$id];
         }
 
-        if (ObjectResetters::class === $id || ObjectResettersInterface::class === $id) {
+        if (isset($this->objectResetterIds[$id])) {
             $objectResetters = new DiDefinitionAutowire(ObjectResetters::class, true);
             $resetters = [];
 

--- a/src/DiContainer/DiContainer.php
+++ b/src/DiContainer/DiContainer.php
@@ -103,6 +103,11 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
     protected readonly array $containerIds;
 
     /**
+     * @var array<class-string, true>
+     */
+    protected readonly array $objectResettersIds;
+
+    /**
      * @param iterable<non-empty-string|non-negative-int, DiDefinitionIdentifierInterface|mixed> $definitions
      * @param iterable<class-string|non-empty-string>                                            $removedDefinitionIds
      * @param iterable<non-empty-string, SourceParameterType>|SourceParametersMutableInterface   $parameters
@@ -123,6 +128,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             ? new ImmediateSourceParameters($parameters)
             : $parameters;
         $this->containerIds = [ContainerInterface::class => true, DiContainerInterface::class => true, __CLASS__ => true];
+        $this->objectResettersIds = [ObjectResetters::class => true, ObjectResettersInterface::class => true];
     }
 
     public function get(string $id): mixed
@@ -142,7 +148,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
     public function set(string $id, mixed $definition): static
     {
-        if (isset($this->containerIds[$id]) || ObjectResettersInterface::class === $id) {
+        if (isset($this->containerIds[$id]) || isset($this->objectResettersIds[$id])) {
             throw new ContainerIdentifierAlreadyRegisteredException(id: $id);
         }
 
@@ -200,20 +206,18 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
      */
     public function getDefinitions(): iterable
     {
-        $needAutoconfigureObjectRestters = $this->config->isConfigureObjectResettersFromDefinitions();
-
         foreach ($this->definitions->getIterator() as $id => $definition) {
             if (!isset($this->containerIds[$id])) {
                 yield $id => $definition;
             }
-
-            if ($needAutoconfigureObjectRestters && ObjectResettersInterface::class === $id) {
-                $needAutoconfigureObjectRestters = false;
-            }
         }
 
-        if ($needAutoconfigureObjectRestters) {
-            yield ObjectResettersInterface::class => $this->autoconfigureObjectResettersDefinition();
+        if ($this->config->isConfigureObjectResettersFromDefinitions()) {
+            foreach ($this->objectResettersIds as $id => $v) {
+                if (!$this->definitions->has($id)) {
+                    yield $id => $this->autoconfigureObjectResettersDefinition();
+                }
+            }
         }
     }
 
@@ -339,7 +343,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
             return $this->diResolvedDefinition[$id];
         }
 
-        if ($this->config->isConfigureObjectResettersFromDefinitions() && ObjectResettersInterface::class === $id) {
+        if ($this->config->isConfigureObjectResettersFromDefinitions() && isset($this->objectResettersIds[$id])) {
             $resetter = $this->autoconfigureObjectResettersDefinition();
             $this->definitions->set($id, $resetter);
 
@@ -422,7 +426,7 @@ class DiContainer implements DiContainerInterface, DiContainerSetterInterface, D
 
     protected function hasViaZeroConfigurationDefinition(string $id): bool
     {
-        if (ObjectResettersInterface::class === $id) {
+        if (isset($this->objectResettersIds[$id])) {
             return $this->config->isConfigureObjectResettersFromDefinitions();
         }
 

--- a/src/DiContainer/DiContainerConfig.php
+++ b/src/DiContainer/DiContainerConfig.php
@@ -12,6 +12,7 @@ final class DiContainerConfig implements DiContainerConfigInterface
         private readonly bool $useZeroConfigurationDefinition = true,
         private readonly bool $useAttribute = true,
         private readonly bool $isSingletonServiceDefault = false,
+        private readonly bool $isConfigureObjectResettersFromDefinitions = true,
     ) {}
 
     public function isSingletonServiceDefault(): bool
@@ -27,5 +28,10 @@ final class DiContainerConfig implements DiContainerConfigInterface
     public function isUseAttribute(): bool
     {
         return $this->useAttribute;
+    }
+
+    public function isConfigureObjectResettersFromDefinitions(): bool
+    {
+        return $this->isConfigureObjectResettersFromDefinitions;
     }
 }

--- a/src/DiContainer/DiContainerNullConfig.php
+++ b/src/DiContainer/DiContainerNullConfig.php
@@ -22,4 +22,9 @@ final class DiContainerNullConfig implements DiContainerConfigInterface
     {
         return false;
     }
+
+    public function isConfigureObjectResettersFromDefinitions(): bool
+    {
+        return false;
+    }
 }

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -304,6 +304,10 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
 
     public function getResetter(): callable|false|string
     {
+        if (false === $this->resetter && $this->isImplementInterface(ResetInterface::class)) {
+            return 'reset';
+        }
+
         return $this->resetter;
     }
 

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -21,6 +21,8 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\Arguments\ArgumentBuilderInterface
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionIdentifierInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
@@ -47,7 +49,7 @@ use function sprintf;
  * @phpstan-type SetupConfigureArgumentsType array<non-empty-string|non-negative-int, DiDefinitionType|mixed>
  * @phpstan-type SetupConfigureItem array{0: SetupConfigureMethod, 1: SetupConfigureArgumentsType}
  */
-final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDefinitionSetupAutowireInterface, DiDefinitionIdentifierInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface, ResetInterface, FreezeInterface
+final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDefinitionSetupAutowireInterface, DiDefinitionIdentifierInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface, ResetInterface, FreezeInterface, DiDefinitionResetterSetterInterface, DiDefinitionResetterInterface
 {
     use BindArgumentsTrait {
         bindArguments as private bindArgumentsInternal;
@@ -84,6 +86,11 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
      * @var null|non-empty-string
      */
     private ?string $containerIdentifier = null;
+
+    /**
+     * @var callable(object): void|false|non-empty-string
+     */
+    private $resetter = false;
 
     /**
      * @param class-string|ReflectionClass $definition
@@ -280,6 +287,24 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
     public function getContainerIdentifier(): ?string
     {
         return $this->containerIdentifier;
+    }
+
+    public function setResetter(callable|string $resetter): static
+    {
+        if ($this->isFrozen) {
+            throw new DiDefinitionException(
+                sprintf('Cannot call \%s::setResetter() on a frozen definition.', __CLASS__)
+            );
+        }
+
+        $this->resetter = $resetter;
+
+        return $this;
+    }
+
+    public function getResetter(): callable|false|string
+    {
+        return $this->resetter;
     }
 
     protected function readTagAttributes(): Generator

--- a/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionAutowire.php
@@ -304,8 +304,12 @@ final class DiDefinitionAutowire implements DiDefinitionAutowireInterface, DiDef
 
     public function getResetter(): callable|false|string
     {
-        if (false === $this->resetter && $this->isImplementInterface(ResetInterface::class)) {
-            return 'reset';
+        try {
+            if (false === $this->resetter && $this->isImplementInterface(ResetInterface::class)) {
+                return 'reset';
+            }
+        } catch (DiDefinitionExceptionInterface) {
+            return false;
         }
 
         return $this->resetter;

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -122,6 +122,12 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
 
     public function setResetter(callable|string $resetter): static
     {
+        if ($this->isFrozen) {
+            throw new DiDefinitionException(
+                sprintf('Cannot call \%s::setResetter() on a frozen definition.', __CLASS__)
+            );
+        }
+
         $this->resetter = $resetter;
 
         return $this;

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -11,6 +11,8 @@ use Kaspi\DiContainer\Attributes\Tag;
 use Kaspi\DiContainer\Exception\AutowireAttributeException;
 use Kaspi\DiContainer\Exception\DiDefinitionException;
 use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
@@ -24,7 +26,7 @@ use function rtrim;
 use function sprintf;
 use function var_export;
 
-final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface, ResetInterface, FreezeInterface
+final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefinitionTagArgumentInterface, DiTaggedObjectDefinitionInterface, ResetInterface, FreezeInterface, DiDefinitionResetterSetterInterface, DiDefinitionResetterInterface
 {
     use TagsOnObjectDefinitionTrait {
         reset as private resetTrait;
@@ -33,6 +35,11 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
     private object $definition;
 
     private ReflectionClass $classDefinitionReflection;
+
+    /**
+     * @var callable(object): void|false|non-empty-string
+     */
+    private $resetter = false;
 
     /**
      * @param class-string|non-empty-string $containerIdentifierOrClass
@@ -106,6 +113,18 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
             $this->definition,
             $this->classDefinitionReflection,
         );
+    }
+
+    public function getResetter(): callable|false|string
+    {
+        return $this->resetter;
+    }
+
+    public function setResetter(callable|string $resetter): static
+    {
+        $this->resetter = $resetter;
+
+        return $this;
     }
 
     protected function readTagAttributes(): Generator

--- a/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
+++ b/src/DiContainer/DiDefinition/DiDefinitionRuntime.php
@@ -16,6 +16,7 @@ use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterfac
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionRuntimeInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiTaggedObjectDefinitionInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
 use Kaspi\DiContainer\Interfaces\FreezeInterface;
 use Kaspi\DiContainer\Interfaces\ResetInterface;
 use Kaspi\DiContainer\Traits\TagsOnObjectDefinitionTrait;
@@ -117,6 +118,14 @@ final class DiDefinitionRuntime implements DiDefinitionRuntimeInterface, DiDefin
 
     public function getResetter(): callable|false|string
     {
+        try {
+            if (false === $this->resetter && $this->isImplementInterface(ResetInterface::class)) {
+                return 'reset';
+            }
+        } catch (DiDefinitionExceptionInterface) {
+            return false;
+        }
+
         return $this->resetter;
     }
 

--- a/src/DiContainer/Exception/ResetterException.php
+++ b/src/DiContainer/Exception/ResetterException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Exception;
+
+use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
+
+final class ResetterException extends ContainerException implements ResetterExceptionInterface {}

--- a/src/DiContainer/Interfaces/DiContainerConfigInterface.php
+++ b/src/DiContainer/Interfaces/DiContainerConfigInterface.php
@@ -11,4 +11,6 @@ interface DiContainerConfigInterface
     public function isUseZeroConfigurationDefinition(): bool;
 
     public function isUseAttribute(): bool;
+
+    public function isConfigureObjectResettersFromDefinitions(): bool;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+interface DiDefinitionResetterInterface extends DiDefinitionResetterSetterInterface
+{
+    /**
+     *  The return value may contain:
+     *   - a non-empty string as the name of the method that performs cleanup for the object
+     *   - `callable` expression that get the object from container and  performs cleanup for this object
+     *   - the value `false` means that the resetter is not defined.
+     *
+     * @return callable(object $object): void|false|non-empty-string
+     */
+    public function getResetter(): callable|false|string;
+}

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterSetterInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterSetterInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Kaspi\DiContainer\Interfaces\DiDefinition;
 
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+
 /**
  * Provides a reset mechanism for container definition.
  *
@@ -20,6 +22,8 @@ interface DiDefinitionResetterSetterInterface
      * @param callable(object $object): void|non-empty-string $resetter
      *
      * @return $this
+     *
+     * @throws DiDefinitionExceptionInterface
      */
     public function setResetter(callable|string $resetter): self;
 }

--- a/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterSetterInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/DiDefinitionResetterSetterInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+/**
+ * Provides a reset mechanism for container definition.
+ *
+ * In some long-running processes, container definitions need to be reset
+ * on every request cycle to prevent memory leaks or to clean up previous changes.
+ */
+interface DiDefinitionResetterSetterInterface
+{
+    /**
+     * The parameter `$resetter` can be present:
+     *  - a non-empty string as the name of the method that performs cleanup for the object
+     *  - `callable` expression that get the object from container and  performs cleanup for this object
+     *
+     * @param callable(object $object): void|non-empty-string $resetter
+     *
+     * @return $this
+     */
+    public function setResetter(callable|string $resetter): self;
+}

--- a/src/DiContainer/Interfaces/DiDefinition/ObjectResettersInterface.php
+++ b/src/DiContainer/Interfaces/DiDefinition/ObjectResettersInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+
+use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+interface ObjectResettersInterface
+{
+    /**
+     * Setups resetters for container entries.
+     *
+     * Deletes previous resetters and creates a new one.
+     *
+     * The iterator key provides the container identifier,
+     * which is used to retrieve a PHP object from the container
+     * using the `\Psr\Container\ContainerInterface::get()` method.
+     *
+     * A resetter can be represented as:
+     *  - a method name of a PHP class that performs the reset of a container entry;
+     *  - a callable expression that accepts a container entry object;
+     *
+     * @param iterable<non-empty-string, callable(object $object): void|non-empty-string> $resetters
+     *
+     * @throws ResetterExceptionInterface
+     */
+    public function setup(iterable $resetters): void;
+
+    /**
+     * @return iterable<non-empty-string, callable(object): void|non-empty-string>
+     */
+    public function resetters(): iterable;
+
+    /**
+     * Resets configured container entries.
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws ResetterExceptionInterface
+     */
+    public function reset(): void;
+}

--- a/src/DiContainer/Interfaces/Exceptions/ResetterExceptionInterface.php
+++ b/src/DiContainer/Interfaces/Exceptions/ResetterExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer\Interfaces\Exceptions;
+
+use Psr\Container\ContainerExceptionInterface;
+
+interface ResetterExceptionInterface extends ContainerExceptionInterface {}

--- a/src/DiContainer/Interfaces/ObjectResettersInterface.php
+++ b/src/DiContainer/Interfaces/ObjectResettersInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kaspi\DiContainer\Interfaces\DiDefinition;
+namespace Kaspi\DiContainer\Interfaces;
 
 use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
 use Psr\Container\ContainerExceptionInterface;

--- a/src/DiContainer/ObjectResetters.php
+++ b/src/DiContainer/ObjectResetters.php
@@ -37,7 +37,9 @@ final class ObjectResetters implements ObjectResettersInterface
 
         foreach ($resetters as $id => $resetter) {
             if (!is_string($id) || '' === $id) {
-                throw new ResetterException('The iterator key must be a non-empty string.');
+                throw new ResetterException(
+                    sprintf('The iterator key must be a non-empty string. Got resetter type "%s" with value %s', get_debug_type($resetter), var_export($resetter, true))
+                );
             }
 
             if (!is_callable($resetter) && !is_string($resetter)) {

--- a/src/DiContainer/ObjectResetters.php
+++ b/src/DiContainer/ObjectResetters.php
@@ -83,14 +83,20 @@ final class ObjectResetters implements ObjectResettersInterface
             );
         }
 
+        if (is_string($resetter) && is_callable($callable = [$object, $resetter])) {
+            ($callable)();
+
+            return;
+        }
+
         if (is_callable($resetter)) {
             ($resetter)($object);
-        } elseif (is_callable($callable = [$object, $resetter])) {
-            ($callable)();
-        } else {
-            throw new ResetterException(
-                sprintf('Resetter must be is `callable(object $object): void` or existing public method in class "%s" class. Got: %s as type "%s".', $object::class, var_export($resetter, true), get_debug_type($resetter))
-            );
+
+            return;
         }
+
+        throw new ResetterException(
+            sprintf('Resetter must be is `callable(object $object): void` or existing public method in class "%s" class. Got: %s as type "%s".', $object::class, var_export($resetter, true), get_debug_type($resetter))
+        );
     }
 }

--- a/src/DiContainer/ObjectResetters.php
+++ b/src/DiContainer/ObjectResetters.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\DiContainer;
+
+use Kaspi\DiContainer\Exception\ResetterException;
+use Kaspi\DiContainer\Interfaces\DiDefinition\ObjectResettersInterface;
+use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+use function get_debug_type;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function sprintf;
+use function var_export;
+
+final class ObjectResetters implements ObjectResettersInterface
+{
+    /**
+     * The iterator key provides the container identifier,
+     *  which is used to retrieve a PHP object from the container
+     *  using the `\Psr\Container\ContainerInterface::get()` method.
+     *
+     * @var array<non-empty-string, callable(object): void|non-empty-string>
+     */
+    private array $resetters = [];
+
+    public function __construct(private readonly ContainerInterface $container) {}
+
+    public function setup(iterable $resetters): void
+    {
+        $this->resetters = [];
+
+        foreach ($resetters as $id => $resetter) {
+            if (!is_string($id) || '' === $id) {
+                throw new ResetterException('The iterator key must be a non-empty string.');
+            }
+
+            if (!is_callable($resetter) && !is_string($resetter)) {
+                throw new ResetterException(sprintf(
+                    'Resetter with the key %s must be is `callable(object $object): void` or non-empty string. Got type: "%s".',
+                    var_export($id, true),
+                    get_debug_type($resetter),
+                ));
+            }
+
+            $this->resetters[$id] = $resetter;
+        }
+    }
+
+    public function resetters(): iterable
+    {
+        yield from $this->resetters;
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->resetters as $id => $resetter) {
+            $this->resetService($id, $resetter);
+        }
+    }
+
+    /**
+     * @param non-empty-string          $id
+     * @param callable|non-empty-string $resetter
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws ResetterExceptionInterface
+     */
+    private function resetService(string $id, callable|string $resetter): void
+    {
+        $object = $this->container->get($id);
+
+        if (!is_object($object)) {
+            throw new ResetterException(
+                sprintf('Entry with container identifier %s should return type "object". Got: "%s"', var_export($id, true), get_debug_type($object))
+            );
+        }
+
+        if (is_callable($resetter)) {
+            ($resetter)($object);
+        } elseif (is_callable($callable = [$object, $resetter])) {
+            ($callable)();
+        } else {
+            throw new ResetterException(
+                sprintf('Resetter must be is `callable(object $object): void` or existing public method in class "%s" class. Got type: "%s".', $object::class, get_debug_type($resetter))
+            );
+        }
+    }
+}

--- a/src/DiContainer/ObjectResetters.php
+++ b/src/DiContainer/ObjectResetters.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Kaspi\DiContainer;
 
 use Kaspi\DiContainer\Exception\ResetterException;
-use Kaspi\DiContainer\Interfaces\DiDefinition\ObjectResettersInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
+use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/DiContainer/ObjectResetters.php
+++ b/src/DiContainer/ObjectResetters.php
@@ -42,9 +42,10 @@ final class ObjectResetters implements ObjectResettersInterface
 
             if (!is_callable($resetter) && !is_string($resetter)) {
                 throw new ResetterException(sprintf(
-                    'Resetter with the key %s must be is `callable(object $object): void` or non-empty string. Got type: "%s".',
+                    'Resetter with the key %s must be is `callable(object $object): void` or non-empty string. Got %s as type "%s".',
                     var_export($id, true),
-                    get_debug_type($resetter),
+                    var_export($resetter, true),
+                    get_debug_type($resetter)
                 ));
             }
 
@@ -88,7 +89,7 @@ final class ObjectResetters implements ObjectResettersInterface
             ($callable)();
         } else {
             throw new ResetterException(
-                sprintf('Resetter must be is `callable(object $object): void` or existing public method in class "%s" class. Got type: "%s".', $object::class, get_debug_type($resetter))
+                sprintf('Resetter must be is `callable(object $object): void` or existing public method in class "%s" class. Got: %s as type "%s".', $object::class, var_export($resetter, true), get_debug_type($resetter))
             );
         }
     }

--- a/src/DiContainer/function.php
+++ b/src/DiContainer/function.php
@@ -16,6 +16,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionTaggedAs;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionArgumentsInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionNoArgumentsInterface;
+use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionResetterSetterInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionSetupAutowireInterface;
 use Kaspi\DiContainer\Interfaces\DiDefinition\DiDefinitionTagArgumentInterface;
 
@@ -25,7 +26,7 @@ if (!function_exists('Kaspi\DiContainer\diAutowire')) { // @codeCoverageIgnore
     /**
      * @param class-string $definition Fully Qualified Class Name
      */
-    function diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionSetupAutowireInterface&DiDefinitionTagArgumentInterface
+    function diAutowire(string $definition, ?bool $isSingleton = null): DiDefinitionResetterSetterInterface&DiDefinitionSetupAutowireInterface&DiDefinitionTagArgumentInterface
     {
         return new DiDefinitionAutowire($definition, $isSingleton);
     }
@@ -109,7 +110,7 @@ if (!function_exists('Kaspi\DiContainer\diRuntime')) { // @codeCoverageIgnore
      * @param class-string|non-empty-string $containerIdentifierOrClass
      * @param null|class-string             $classDefinition
      */
-    function diRuntime(string $containerIdentifierOrClass, ?string $message = null, ?string $classDefinition = null): DiDefinitionTagArgumentInterface
+    function diRuntime(string $containerIdentifierOrClass, ?string $message = null, ?string $classDefinition = null): DiDefinitionResetterSetterInterface&DiDefinitionTagArgumentInterface
     {
         return new DiDefinitionRuntime($containerIdentifierOrClass, $message, $classDefinition);
     }

--- a/tests/Compiler/CompilableDefinition/ObjectEntry/CompiledObjectResettersTest.php
+++ b/tests/Compiler/CompilableDefinition/ObjectEntry/CompiledObjectResettersTest.php
@@ -132,8 +132,7 @@ class CompiledObjectResettersTest extends TestCase
   \'service.foo\' => static function (\Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures\Foo $foo): void {},
   \'service.baz\' => [\'\\\Tests\\\Compiler\\\CompilableDefinition\\\ObjectEntry\\\Fixtures\\\BazResetter\', \'doReset\'],
   \'service.bar\' => \'reset\',
-]
-)',
+])',
             $compiledEntry->getStatements()[1]
         );
     }

--- a/tests/Compiler/CompilableDefinition/ObjectEntry/CompiledObjectResettersTest.php
+++ b/tests/Compiler/CompilableDefinition/ObjectEntry/CompiledObjectResettersTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Compiler\CompilableDefinition\ObjectEntry;
+
+use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\ObjectEntry;
+use Kaspi\DiContainer\Compiler\CompiledEntry;
+use Kaspi\DiContainer\Compiler\DiDefinitionTransformer;
+use Kaspi\DiContainer\Compiler\Helper;
+use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
+use Kaspi\DiContainer\Interfaces\Compiler\DiContainerDefinitionsInterface;
+use Kaspi\DiContainer\Interfaces\Compiler\Exception\DefinitionCompileExceptionInterface;
+use Kaspi\DiContainer\Interfaces\DiContainerInterface;
+use Kaspi\DiContainer\Interfaces\Finder\FinderClosureCodeInterface;
+use Kaspi\DiContainer\ObjectResetters;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use stdClass;
+use Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures\BazResetter;
+use Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures\Foo;
+
+/**
+ * @internal
+ */
+#[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(GetEntry::class)]
+#[CoversClass(ObjectEntry::class)]
+#[CoversClass(CompiledEntry::class)]
+#[CoversClass(DiDefinitionTransformer::class)]
+#[CoversClass(Helper::class)]
+#[CoversClass(ArgumentBuilder::class)]
+#[CoversClass(DiDefinitionGet::class)]
+#[CoversClass(\Kaspi\DiContainer\Helper::class)]
+class CompiledObjectResettersTest extends TestCase
+{
+    protected DiContainerDefinitionsInterface $diContainerDefinitionsMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $containerMock = $this->createMock(DiContainerInterface::class);
+        $containerMock->method('has')
+            ->with(ContainerInterface::class)
+            ->willReturn(true)
+        ;
+
+        $diContainerDefinitionsMock = $this->createMock(DiContainerDefinitionsInterface::class);
+        $diContainerDefinitionsMock->method('getContainer')
+            ->willReturn($containerMock)
+        ;
+
+        $this->diContainerDefinitionsMock = $diContainerDefinitionsMock;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->diContainerDefinitionsMock);
+    }
+
+    public function testSetupMethodArgumentNotIterable(): void
+    {
+        $this->expectException(DefinitionCompileExceptionInterface::class);
+        $this->expectExceptionMessage('The first argument for Kaspi\DiContainer\ObjectResetters::setup() should be `iterable` type.');
+
+        $definition = (new DiDefinitionAutowire(ObjectResetters::class))
+            ->setup('setup', [new stdClass()])
+        ;
+
+        (new ObjectEntry(
+            $definition,
+            $this->diContainerDefinitionsMock,
+            new DiDefinitionTransformer($this->createMock(FinderClosureCodeInterface::class)),
+        ))->compile('$this');
+    }
+
+    public function testSetupMethodContainsUnsupportedTypeResetter(): void
+    {
+        $this->expectException(DefinitionCompileExceptionInterface::class);
+        $this->expectExceptionMessage('The resetter for container identifier \'service.foo\' type should be is `callable` or `string`.');
+
+        $definition = (new DiDefinitionAutowire(ObjectResetters::class))
+            ->setup('setup', [['service.foo' => new stdClass()]])
+        ;
+
+        (new ObjectEntry(
+            $definition,
+            $this->diContainerDefinitionsMock,
+            new DiDefinitionTransformer($this->createMock(FinderClosureCodeInterface::class)),
+        ))->compile('$this');
+    }
+
+    public function testCompileResetters(): void
+    {
+        $definition = (new DiDefinitionAutowire(ObjectResetters::class))
+            ->setup('setup', [
+                [
+                    'service.foo' => static function (Foo $foo): void {},
+                    'service.baz' => [BazResetter::class, 'doReset'],
+                    'service.bar' => 'reset',
+                ],
+            ])
+        ;
+
+        $finderClosureCode = $this->createMock(FinderClosureCodeInterface::class);
+        $finderClosureCode->method('getCode')
+            ->willReturn('static function (\Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures\Foo $foo): void {}')
+        ;
+
+        $compiledEntry = (new ObjectEntry(
+            $definition,
+            $this->diContainerDefinitionsMock,
+            new DiDefinitionTransformer($finderClosureCode),
+        ))->compile('$this');
+
+        self::assertEquals('$object', $compiledEntry->getExpression());
+
+        self::assertCount(2, $compiledEntry->getStatements());
+
+        self::assertEquals(
+            '$object = new \Kaspi\DiContainer\ObjectResetters(
+  $this->get(\'Psr\\\Container\\\ContainerInterface\'),
+)',
+            $compiledEntry->getStatements()[0]
+        );
+        self::assertEquals(
+            '$object->setup([
+  \'service.foo\' => static function (\Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures\Foo $foo): void {},
+  \'service.baz\' => [\'\\\Tests\\\Compiler\\\CompilableDefinition\\\ObjectEntry\\\Fixtures\\\BazResetter\', \'doReset\'],
+  \'service.bar\' => \'reset\',
+]
+)',
+            $compiledEntry->getStatements()[1]
+        );
+    }
+}

--- a/tests/Compiler/CompilableDefinition/ObjectEntry/Fixtures/Bar.php
+++ b/tests/Compiler/CompilableDefinition/ObjectEntry/Fixtures/Bar.php
@@ -4,4 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures;
 
-final class Bar {}
+use Kaspi\DiContainer\Interfaces\ResetInterface;
+
+final class Bar implements ResetInterface
+{
+    public function reset(): void
+    {
+        // TODO: Implement reset() method.
+    }
+}

--- a/tests/Compiler/CompilableDefinition/ObjectEntry/Fixtures/BazResetter.php
+++ b/tests/Compiler/CompilableDefinition/ObjectEntry/Fixtures/BazResetter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Compiler\CompilableDefinition\ObjectEntry\Fixtures;
+
+final class BazResetter
+{
+    public static function doReset(Baz $baz): void {}
+}

--- a/tests/ContainerBuilder/DiContainerBuilderTest.php
+++ b/tests/ContainerBuilder/DiContainerBuilderTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\ContainerBuilder;
 
 use Generator;
+use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ObjectEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ValueEntry;
 use Kaspi\DiContainer\Compiler\CompiledEntries;
@@ -23,6 +25,7 @@ use Kaspi\DiContainer\DiContainerNullConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\DefinitionsLoaderException;
 use Kaspi\DiContainer\Finder\FinderClosureCode;
@@ -77,6 +80,9 @@ use function random_bytes;
 #[CoversClass(FinderClosureCode::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 #[CoversClass(FreezeTrait::class)]
+#[CoversClass(AttributeReader::class)]
+#[CoversClass(GetEntry::class)]
+#[CoversClass(DiDefinitionGet::class)]
 class DiContainerBuilderTest extends TestCase
 {
     public function testDefinitionLoaderImportThrowException(): void

--- a/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
@@ -27,6 +27,7 @@ use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Finder\FinderFullyQualifiedNameInterface;
 use Kaspi\DiContainer\Interfaces\FinderFullyQualifiedNameCollectionInterface;
+use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
@@ -103,6 +104,7 @@ class DefinitionsLoaderImportTest extends TestCase
         $containerIds = array_keys(iterator_to_array($container->getDefinitions()));
 
         $expectContainerIds = [
+            ObjectResettersInterface::class,
             Fixtures\Import\SubDirectory\One::class,
             Two::class,
             Fixtures\Import\One::class,

--- a/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderImportTest.php
@@ -27,7 +27,6 @@ use Kaspi\DiContainer\Interfaces\Exceptions\AutowireExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Exceptions\DefinitionsLoaderExceptionInterface;
 use Kaspi\DiContainer\Interfaces\Finder\FinderFullyQualifiedNameInterface;
 use Kaspi\DiContainer\Interfaces\FinderFullyQualifiedNameCollectionInterface;
-use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
 use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
 use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
@@ -42,7 +41,6 @@ use Tests\DefinitionsLoader\Fixtures\ImportConfigInterface\Foo;
 use Tests\DefinitionsLoader\Fixtures\ImportConfigInterface\FooInterface;
 
 use function array_keys;
-use function iterator_to_array;
 use function Kaspi\DiContainer\diAutowire;
 use function sort;
 
@@ -98,13 +96,13 @@ class DefinitionsLoaderImportTest extends TestCase
         $container = (new DiContainerFactory(
             new DiContainerConfig(
                 isSingletonServiceDefault: false, // by default service none-singleton
+                isConfigureObjectResettersFromDefinitions: false,
             )
         ))->make($loader->definitions());
 
-        $containerIds = array_keys(iterator_to_array($container->getDefinitions()));
+        $containerIds = array_keys([...$container->getDefinitions()]);
 
         $expectContainerIds = [
-            ObjectResettersInterface::class,
             Fixtures\Import\SubDirectory\One::class,
             Two::class,
             Fixtures\Import\One::class,

--- a/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
+++ b/tests/DiContainer/RemovedDefinitionIds/RemovedDefinitionIdsTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\DiContainer\RemovedDefinitionIds;
 
 use Kaspi\DiContainer\AttributeReader;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\GetEntry;
 use Kaspi\DiContainer\Compiler\CompilableDefinition\ObjectEntry;
+use Kaspi\DiContainer\Compiler\CompilableDefinition\ValueEntry;
 use Kaspi\DiContainer\Compiler\CompiledEntries;
 use Kaspi\DiContainer\Compiler\CompiledEntry;
 use Kaspi\DiContainer\Compiler\ContainerCompiler;
@@ -17,7 +19,9 @@ use Kaspi\DiContainer\DefinitionsLoader;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerBuilder;
 use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Finder\FinderClosureCode;
 use Kaspi\DiContainer\Finder\FinderFile;
@@ -71,6 +75,11 @@ use function random_bytes;
 #[CoversClass(FinderClosureCode::class)]
 #[CoversClass(SourceDefinitionItem::class)]
 #[CoversClass(FreezeTrait::class)]
+#[CoversClass(GetEntry::class)]
+#[CoversClass(ValueEntry::class)]
+#[CoversClass(\Kaspi\DiContainer\Compiler\Helper::class)]
+#[CoversClass(ArgumentBuilder::class)]
+#[CoversClass(DiDefinitionGet::class)]
 class RemovedDefinitionIdsTest extends TestCase
 {
     public function testRemovedDefinitionIds(): void

--- a/tests/DiContainer/ResolveSelfContainerTest.php
+++ b/tests/DiContainer/ResolveSelfContainerTest.php
@@ -7,6 +7,7 @@ namespace Tests\DiContainer;
 use Generator;
 use Kaspi\DiContainer\DiContainer;
 use Kaspi\DiContainer\DiContainerConfig;
+use Kaspi\DiContainer\DiContainerNullConfig;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
 use Kaspi\DiContainer\Exception\ContainerIdentifierAlreadyRegisteredException;
 use Kaspi\DiContainer\Exception\NotFoundException;
@@ -37,6 +38,7 @@ use stdClass;
 #[CoversClass(ContainerIdentifierAlreadyRegisteredException::class)]
 #[CoversClass(NotFoundException::class)]
 #[CoversClass(SourceDefinitionItem::class)]
+#[CoversClass(DiContainerNullConfig::class)]
 class ResolveSelfContainerTest extends TestCase
 {
     #[DataProvider('dataProvider')]

--- a/tests/ObjectResetters/AutowireResetterTest.php
+++ b/tests/ObjectResetters/AutowireResetterTest.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\ObjectResetters\Fixtures\Bar;
 use Tests\ObjectResetters\Fixtures\Foo;
 use Tests\ObjectResetters\Fixtures\FooResetter;
 
@@ -79,5 +80,12 @@ class AutowireResetterTest extends TestCase
             Foo::class,
             '\Tests\ObjectResetters\Fixtures\resetFoo',
         ];
+    }
+
+    public function testResetterViaResetterInterface(): void
+    {
+        $definition = new DiDefinitionAutowire(Bar::class);
+
+        self::assertEquals('reset', $definition->getResetter());
     }
 }

--- a/tests/ObjectResetters/AutowireResetterTest.php
+++ b/tests/ObjectResetters/AutowireResetterTest.php
@@ -88,4 +88,11 @@ class AutowireResetterTest extends TestCase
 
         self::assertEquals('reset', $definition->getResetter());
     }
+
+    public function testResetterViaResetterInterfaceIdIsWrongClassName(): void
+    {
+        $definition = new DiDefinitionAutowire(NotFound::class);
+
+        self::assertFalse($definition->getResetter());
+    }
 }

--- a/tests/ObjectResetters/AutowireResetterTest.php
+++ b/tests/ObjectResetters/AutowireResetterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters;
+
+use Generator;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Traits\FreezeTrait;
+use Kaspi\DiContainer\Traits\TagsTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\ObjectResetters\Fixtures\Foo;
+use Tests\ObjectResetters\Fixtures\FooResetter;
+
+/**
+ * @internal
+ */
+#[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(TagsTrait::class)]
+#[CoversClass(FreezeTrait::class)]
+class AutowireResetterTest extends TestCase
+{
+    public function testResetterOnFrozenDefinition(): void
+    {
+        $definition = (new DiDefinitionAutowire(Foo::class))
+            ->setResetter('flush')
+        ;
+
+        $definition->freeze();
+
+        self::assertEquals('flush', $definition->getResetter());
+
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/^Cannot call.+DiDefinitionAutowire::setResetter\(\) on a frozen definition/');
+
+        $definition->setResetter('\Tests\ObjectResetters\Fixtures\Foo\resetFoo');
+    }
+
+    public function testResetterNotDefined(): void
+    {
+        $definition = new DiDefinitionAutowire(Foo::class);
+
+        self::assertFalse($definition->getResetter());
+    }
+
+    #[DataProvider('dataProviderSetResetter')]
+    public function testSetResetter(string $definition, callable|string $resetter): void
+    {
+        $definition = (new DiDefinitionAutowire($definition))
+            ->setResetter($resetter)
+        ;
+
+        self::assertSame($resetter, $definition->getResetter());
+    }
+
+    public static function dataProviderSetResetter(): Generator
+    {
+        yield 'as method string' => [
+            Foo::class,
+            'flush',
+        ];
+
+        yield 'as Closure' => [
+            Foo::class,
+            static function (Foo $foo): void {
+                $foo->foo = 'fn';
+            },
+        ];
+
+        yield 'as callable through static method' => [
+            Foo::class,
+            [FooResetter::class, 'doReset'],
+        ];
+
+        yield 'as callable through function' => [
+            Foo::class,
+            '\Tests\ObjectResetters\Fixtures\resetFoo',
+        ];
+    }
+}

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters;
+
+use Kaspi\DiContainer\DiContainer;
+use Kaspi\DiContainer\DiContainerNullConfig;
+use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
+use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
+use Kaspi\DiContainer\Helper;
+use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
+use Kaspi\DiContainer\ObjectResetters;
+use Kaspi\DiContainer\Parameters\ImmediateSourceParameters;
+use Kaspi\DiContainer\SourceDefinitions\AbstractSourceDefinitionsMutable;
+use Kaspi\DiContainer\SourceDefinitions\ImmediateSourceDefinitionsMutable;
+use Kaspi\DiContainer\SourceDefinitions\SourceDefinitionItem;
+use Kaspi\DiContainer\Traits\FreezeTrait;
+use Kaspi\DiContainer\Traits\TagsTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tests\ObjectResetters\Fixtures\Foo;
+use Tests\ObjectResetters\Fixtures\FooResetter;
+
+use function Kaspi\DiContainer\diAutowire;
+use function Kaspi\DiContainer\diRuntime;
+
+/**
+ * @internal
+ */
+#[CoversClass(ArgumentBuilder::class)]
+#[CoversClass(ArgumentResolver::class)]
+#[CoversClass(AbstractSourceDefinitionsMutable::class)]
+#[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(DiDefinitionValue::class)]
+#[CoversClass(DiContainer::class)]
+#[CoversClass(DiContainerNullConfig::class)]
+#[CoversClass(DiDefinitionGet::class)]
+#[CoversClass(ImmediateSourceParameters::class)]
+#[CoversClass(ImmediateSourceDefinitionsMutable::class)]
+#[CoversClass(Helper::class)]
+#[CoversClass(SourceDefinitionItem::class)]
+#[CoversClass(TagsTrait::class)]
+#[CoversClass(FreezeTrait::class)]
+#[CoversClass(ObjectResetters::class)]
+#[CoversFunction('Kaspi\DiContainer\diAutowire')]
+#[CoversFunction('Kaspi\DiContainer\diRuntime')]
+class DiContainerAutoconfigureObjectResetterTest extends TestCase
+{
+    #[TestWith([
+        [],
+        ObjectResetters::class,
+    ])]
+    #[TestWith([
+        [],
+        ObjectResettersInterface::class,
+    ])]
+    #[TestWith([
+        [ObjectResetters::class => new DiDefinitionAutowire(ObjectResetters::class)],
+        ObjectResetters::class,
+    ])]
+    #[TestWith([
+        [ObjectResettersInterface::class => new DiDefinitionAutowire(ObjectResetters::class)],
+        ObjectResettersInterface::class,
+    ])]
+    public function testHasAlwaysTrue(array $definitions, string $id): void
+    {
+        $container = new DiContainer($definitions);
+
+        self::assertTrue($container->has($id));
+    }
+
+    public function testGetObjectResettersAutoconfiguredByDiContainerForDiAutowire(): void
+    {
+        $container = new DiContainer([
+            diAutowire(Foo::class, true)
+                ->setResetter('flush'),
+        ]);
+
+        $container->get(Foo::class)->foo = 'bar';
+
+        self::assertEquals('bar', $container->get(Foo::class)->foo);
+
+        $resetter = $container->get(ObjectResettersInterface::class);
+        $resetter->reset();
+
+        self::assertEquals('null', $container->get(Foo::class)->foo);
+    }
+
+    public function testGetObjectResettersAutoconfiguredByDiContainerForDiRuntime(): void
+    {
+        $container = new DiContainer([
+            diRuntime(Foo::class)
+                ->setResetter(FooResetter::class.'::doReset'),
+        ]);
+
+        $foo = new Foo();
+        $foo->foo = 'bar';
+
+        $container->set(Foo::class, $foo);
+
+        $container->get(Foo::class)->foo = 'bar';
+
+        self::assertEquals('bar', $container->get(Foo::class)->foo);
+
+        $resetter = $container->get(ObjectResetters::class);
+        $resetter->reset();
+
+        self::assertEquals('foo', $container->get(Foo::class)->foo);
+    }
+}

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -26,6 +26,7 @@ use Kaspi\DiContainer\Traits\FreezeTrait;
 use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 use Tests\ObjectResetters\Fixtures\Foo;
@@ -64,16 +65,22 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
     {
         $container = new DiContainer(
             [
-                ObjectResettersInterface::class => new DiDefinitionAutowire(ObjectResetters::class),
+                diAutowire(ObjectResetters::class),
             ],
             config: new DiContainerConfig(isConfigureObjectResettersFromDefinitions: true)
         );
 
-        self::assertTrue($container->has(ObjectResettersInterface::class));
-        self::assertArrayHasKey(ObjectResettersInterface::class, [...$container->getDefinitions()]);
+        self::assertTrue($container->has(ObjectResetters::class));
+
+        $definitions = [...$container->getDefinitions()];
+
+        self::assertCount(1, $definitions);
+        self::assertArrayHasKey(ObjectResetters::class, $definitions);
     }
 
-    public function testAutoconfigureObjectResettersOff(): void
+    #[TestWith([ObjectResettersInterface::class])]
+    #[TestWith([ObjectResetters::class])]
+    public function testAutoconfigureObjectResettersOff(string $entryId): void
     {
         $container = new DiContainer(
             [
@@ -87,15 +94,15 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
         );
 
         self::assertTrue($container->has(Foo::class));
-        self::assertFalse($container->has(ObjectResettersInterface::class));
+        self::assertFalse($container->has($entryId));
 
         $definitions = [...$container->getDefinitions()];
 
-        self::assertArrayNotHasKey(ObjectResettersInterface::class, $definitions);
+        self::assertArrayNotHasKey($entryId, $definitions);
         self::assertArrayHasKey(Foo::class, $definitions);
 
         $this->expectException(NotFoundExceptionInterface::class);
-        $container->getDefinition(ObjectResettersInterface::class);
+        $container->getDefinition($entryId);
     }
 
     public function testGetObjectResettersAutoconfiguredByDiContainerForDiAutowire(): void
@@ -115,9 +122,13 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
         foreach ([ObjectResetters::class, ObjectResettersInterface::class] as $objectResettersEntryId) {
             $resetter = $container->get($objectResettersEntryId);
             $resetter->reset();
-        }
 
-        self::assertEquals('null', $container->get(Foo::class)->foo);
+            self::assertEquals('null', $container->get(Foo::class)->foo);
+
+            $container->get(Foo::class)->foo = 'bar';
+
+            self::assertEquals('bar', $container->get(Foo::class)->foo);
+        }
     }
 
     public function testGetObjectResettersAutoconfiguredByDiContainerForDiRuntime(): void
@@ -139,7 +150,7 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
 
         self::assertEquals('bar', $container->get(Foo::class)->foo);
 
-        $resetter = $container->get(ObjectResettersInterface::class);
+        $resetter = $container->get(ObjectResetters::class);
         $resetter->reset();
 
         self::assertEquals('foo', $container->get(Foo::class)->foo);

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -9,6 +9,7 @@ use Kaspi\DiContainer\DiContainerNullConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
@@ -38,6 +39,7 @@ use function Kaspi\DiContainer\diRuntime;
 #[CoversClass(ArgumentResolver::class)]
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
+#[CoversClass(DiDefinitionCallable::class)]
 #[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(DiContainer::class)]

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -58,15 +58,7 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
 {
     #[TestWith([
         [],
-        ObjectResetters::class,
-    ])]
-    #[TestWith([
-        [],
         ObjectResettersInterface::class,
-    ])]
-    #[TestWith([
-        [ObjectResetters::class => new DiDefinitionAutowire(ObjectResetters::class)],
-        ObjectResetters::class,
     ])]
     #[TestWith([
         [ObjectResettersInterface::class => new DiDefinitionAutowire(ObjectResetters::class)],
@@ -112,7 +104,7 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
 
         self::assertEquals('bar', $container->get(Foo::class)->foo);
 
-        $resetter = $container->get(ObjectResetters::class);
+        $resetter = $container->get(ObjectResettersInterface::class);
         $resetter->reset();
 
         self::assertEquals('foo', $container->get(Foo::class)->foo);

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\ObjectResetters;
 
+use Kaspi\DiContainer\AttributeReader;
 use Kaspi\DiContainer\DiContainer;
-use Kaspi\DiContainer\DiContainerNullConfig;
+use Kaspi\DiContainer\DiContainerConfig;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentBuilder;
 use Kaspi\DiContainer\DiDefinition\Arguments\ArgumentResolver;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire;
@@ -13,6 +14,7 @@ use Kaspi\DiContainer\DiDefinition\DiDefinitionCallable;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionGet;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
 use Kaspi\DiContainer\DiDefinition\DiDefinitionValue;
+use Kaspi\DiContainer\Exception\NotFoundException;
 use Kaspi\DiContainer\Helper;
 use Kaspi\DiContainer\Interfaces\ObjectResettersInterface;
 use Kaspi\DiContainer\ObjectResetters;
@@ -24,8 +26,8 @@ use Kaspi\DiContainer\Traits\FreezeTrait;
 use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
 use Tests\ObjectResetters\Fixtures\Foo;
 use Tests\ObjectResetters\Fixtures\FooResetter;
 
@@ -38,12 +40,13 @@ use function Kaspi\DiContainer\diRuntime;
 #[CoversClass(ArgumentBuilder::class)]
 #[CoversClass(ArgumentResolver::class)]
 #[CoversClass(AbstractSourceDefinitionsMutable::class)]
+#[CoversClass(AttributeReader::class)]
 #[CoversClass(DiDefinitionAutowire::class)]
 #[CoversClass(DiDefinitionCallable::class)]
 #[CoversClass(DiDefinitionRuntime::class)]
 #[CoversClass(DiDefinitionValue::class)]
 #[CoversClass(DiContainer::class)]
-#[CoversClass(DiContainerNullConfig::class)]
+#[CoversClass(DiContainerConfig::class)]
 #[CoversClass(DiDefinitionGet::class)]
 #[CoversClass(ImmediateSourceParameters::class)]
 #[CoversClass(ImmediateSourceDefinitionsMutable::class)]
@@ -52,31 +55,58 @@ use function Kaspi\DiContainer\diRuntime;
 #[CoversClass(TagsTrait::class)]
 #[CoversClass(FreezeTrait::class)]
 #[CoversClass(ObjectResetters::class)]
+#[CoversClass(NotFoundException::class)]
 #[CoversFunction('Kaspi\DiContainer\diAutowire')]
 #[CoversFunction('Kaspi\DiContainer\diRuntime')]
 class DiContainerAutoconfigureObjectResetterTest extends TestCase
 {
-    #[TestWith([
-        [],
-        ObjectResettersInterface::class,
-    ])]
-    #[TestWith([
-        [ObjectResettersInterface::class => new DiDefinitionAutowire(ObjectResetters::class)],
-        ObjectResettersInterface::class,
-    ])]
-    public function testHasAlwaysTrue(array $definitions, string $id): void
+    public function testManuallyConfigure(): void
     {
-        $container = new DiContainer($definitions);
+        $container = new DiContainer(
+            [
+                ObjectResettersInterface::class => new DiDefinitionAutowire(ObjectResetters::class),
+            ],
+            config: new DiContainerConfig(isConfigureObjectResettersFromDefinitions: true)
+        );
 
-        self::assertTrue($container->has($id));
+        self::assertTrue($container->has(ObjectResettersInterface::class));
+        self::assertArrayHasKey(ObjectResettersInterface::class, [...$container->getDefinitions()]);
+    }
+
+    public function testAutoconfigureObjectResettersOff(): void
+    {
+        $container = new DiContainer(
+            [
+                diAutowire(Foo::class),
+            ],
+            config: new DiContainerConfig(
+                useZeroConfigurationDefinition: true,
+                useAttribute: true,
+                isConfigureObjectResettersFromDefinitions: false
+            )
+        );
+
+        self::assertTrue($container->has(Foo::class));
+        self::assertFalse($container->has(ObjectResettersInterface::class));
+
+        $definitions = [...$container->getDefinitions()];
+
+        self::assertArrayNotHasKey(ObjectResettersInterface::class, $definitions);
+        self::assertArrayHasKey(Foo::class, $definitions);
+
+        $this->expectException(NotFoundExceptionInterface::class);
+        $container->getDefinition(ObjectResettersInterface::class);
     }
 
     public function testGetObjectResettersAutoconfiguredByDiContainerForDiAutowire(): void
     {
-        $container = new DiContainer([
-            diAutowire(Foo::class, true)
-                ->setResetter('flush'),
-        ]);
+        $container = new DiContainer(
+            [
+                diAutowire(Foo::class, true)
+                    ->setResetter('flush'),
+            ],
+            config: new DiContainerConfig(isConfigureObjectResettersFromDefinitions: true),
+        );
 
         $container->get(Foo::class)->foo = 'bar';
 
@@ -90,10 +120,13 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
 
     public function testGetObjectResettersAutoconfiguredByDiContainerForDiRuntime(): void
     {
-        $container = new DiContainer([
-            diRuntime(Foo::class)
-                ->setResetter(FooResetter::class.'::doReset'),
-        ]);
+        $container = new DiContainer(
+            [
+                diRuntime(Foo::class)
+                    ->setResetter(FooResetter::class.'::doReset'),
+            ],
+            config: new DiContainerConfig(isConfigureObjectResettersFromDefinitions: true),
+        );
 
         $foo = new Foo();
         $foo->foo = 'bar';

--- a/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
+++ b/tests/ObjectResetters/DiContainerAutoconfigureObjectResetterTest.php
@@ -112,8 +112,10 @@ class DiContainerAutoconfigureObjectResetterTest extends TestCase
 
         self::assertEquals('bar', $container->get(Foo::class)->foo);
 
-        $resetter = $container->get(ObjectResettersInterface::class);
-        $resetter->reset();
+        foreach ([ObjectResetters::class, ObjectResettersInterface::class] as $objectResettersEntryId) {
+            $resetter = $container->get($objectResettersEntryId);
+            $resetter->reset();
+        }
 
         self::assertEquals('null', $container->get(Foo::class)->foo);
     }

--- a/tests/ObjectResetters/DiRuntimeResetterTest.php
+++ b/tests/ObjectResetters/DiRuntimeResetterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters;
+
+use Generator;
+use Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime;
+use Kaspi\DiContainer\Interfaces\Exceptions\DiDefinitionExceptionInterface;
+use Kaspi\DiContainer\Traits\FreezeTrait;
+use Kaspi\DiContainer\Traits\TagsTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\ObjectResetters\Fixtures\Foo;
+use Tests\ObjectResetters\Fixtures\FooResetter;
+
+/**
+ * @internal
+ */
+#[CoversClass(DiDefinitionRuntime::class)]
+#[CoversClass(TagsTrait::class)]
+#[CoversClass(FreezeTrait::class)]
+class DiRuntimeResetterTest extends TestCase
+{
+    public function testResetterOnFrozenDefinition(): void
+    {
+        $definition = (new DiDefinitionRuntime(Foo::class))
+            ->setResetter('flush')
+        ;
+
+        $definition->freeze();
+
+        self::assertEquals('flush', $definition->getResetter());
+
+        $this->expectException(DiDefinitionExceptionInterface::class);
+        $this->expectExceptionMessageMatches('/^Cannot call.+DiDefinitionRuntime::setResetter\(\) on a frozen definition/');
+
+        $definition->setResetter('\Tests\ObjectResetters\Fixtures\Foo\resetFoo');
+    }
+
+    public function testResetterNotDefined(): void
+    {
+        $definition = new DiDefinitionRuntime(Foo::class);
+
+        self::assertFalse($definition->getResetter());
+    }
+
+    #[DataProvider('dataProviderSetResetter')]
+    public function testSetResetter(string $definition, callable|string $resetter): void
+    {
+        $definition = (new DiDefinitionRuntime($definition))
+            ->setResetter($resetter)
+        ;
+
+        self::assertSame($resetter, $definition->getResetter());
+    }
+
+    public static function dataProviderSetResetter(): Generator
+    {
+        yield 'as method string' => [
+            Foo::class,
+            'flush',
+        ];
+
+        yield 'as Closure' => [
+            Foo::class,
+            static function (Foo $foo): void {
+                $foo->foo = 'fn';
+            },
+        ];
+
+        yield 'as callable through static method' => [
+            Foo::class,
+            [FooResetter::class, 'doReset'],
+        ];
+
+        yield 'as callable through function' => [
+            Foo::class,
+            '\Tests\ObjectResetters\Fixtures\resetFoo',
+        ];
+    }
+}

--- a/tests/ObjectResetters/DiRuntimeResetterTest.php
+++ b/tests/ObjectResetters/DiRuntimeResetterTest.php
@@ -12,6 +12,7 @@ use Kaspi\DiContainer\Traits\TagsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\ObjectResetters\Fixtures\Bar;
 use Tests\ObjectResetters\Fixtures\Foo;
 use Tests\ObjectResetters\Fixtures\FooResetter;
 
@@ -79,5 +80,19 @@ class DiRuntimeResetterTest extends TestCase
             Foo::class,
             '\Tests\ObjectResetters\Fixtures\resetFoo',
         ];
+    }
+
+    public function testResetterViaResetterInterface(): void
+    {
+        $definition = new DiDefinitionRuntime(Bar::class);
+
+        self::assertEquals('reset', $definition->getResetter());
+    }
+
+    public function testResetterViaResetterInterfaceIdIsSimpleString(): void
+    {
+        $definition = new DiDefinitionRuntime('services.foo_bar');
+
+        self::assertFalse($definition->getResetter());
     }
 }

--- a/tests/ObjectResetters/Fixtures/Bar.php
+++ b/tests/ObjectResetters/Fixtures/Bar.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters\Fixtures;
+
+use Kaspi\DiContainer\Interfaces\ResetInterface;
+
+final class Bar implements ResetInterface
+{
+    public function __construct(private ?string $name) {}
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function reset(): void
+    {
+        $this->name = null;
+    }
+}

--- a/tests/ObjectResetters/Fixtures/Foo.php
+++ b/tests/ObjectResetters/Fixtures/Foo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters\Fixtures;
+
+final class Foo
+{
+    public string $foo;
+
+    public function flush(): void
+    {
+        $this->foo = 'null';
+    }
+}
+
+function resetFoo(Foo $foo): void
+{
+    $foo->foo = 'fn';
+}

--- a/tests/ObjectResetters/Fixtures/FooResetter.php
+++ b/tests/ObjectResetters/Fixtures/FooResetter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters\Fixtures;
+
+final class FooResetter
+{
+    public static function doReset(Foo $foo): void
+    {
+        $foo->foo = 'foo';
+    }
+}

--- a/tests/ObjectResetters/ObjectResettersTest.php
+++ b/tests/ObjectResetters/ObjectResettersTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ObjectResetters;
+
+use Closure;
+use Generator;
+use Kaspi\DiContainer\Interfaces\Exceptions\ResetterExceptionInterface;
+use Kaspi\DiContainer\ObjectResetters;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use stdClass;
+
+/**
+ * @internal
+ */
+#[CoversClass(ObjectResetters::class)]
+class ObjectResettersTest extends TestCase
+{
+    #[TestWith([
+        [0 => 'foo'],
+        'The iterator key must be a non-empty string.',
+    ])]
+    #[TestWith([
+        ['' => 'foo'],
+        'The iterator key must be a non-empty string.',
+    ])]
+    #[TestWith([
+        ['foo' => new stdClass()],
+        'Resetter with the key \'foo\' must be is',
+    ])]
+    #[TestWith([
+        ['foo' => true],
+        'Resetter with the key \'foo\' must be is',
+    ])]
+    public function testObjectResettersSetupException(iterable $setupResetters, string $expectExceptionMessage): void
+    {
+        $this->expectException(ResetterExceptionInterface::class);
+        $this->expectExceptionMessage($expectExceptionMessage);
+
+        (new ObjectResetters($this->createMock(ContainerInterface::class)))
+            ->setup($setupResetters)
+        ;
+    }
+
+    public function testObjectResettersGetConfiguresResetters(): void
+    {
+        $setupResetters = static function () {
+            yield 'foo' => 'foo';
+
+            yield 'bar' => static function ($object): void {
+                $object->foo = [];
+            };
+
+            yield Fixtures\Foo::class => [Fixtures\FooResetter::class, 'doReset'];
+        };
+
+        $objectResetters = new ObjectResetters($this->createMock(ContainerInterface::class));
+        $objectResetters->setup($setupResetters());
+
+        $resetters = [...$objectResetters->resetters()];
+
+        self::assertCount(3, $resetters);
+        self::assertEquals('foo', $resetters['foo']);
+        self::assertInstanceOf(Closure::class, $resetters['bar']);
+        self::assertEquals([Fixtures\FooResetter::class, 'doReset'], $resetters[Fixtures\Foo::class]);
+
+        // Deletes previous resetters and creates a new one when call `setup()` again.
+        $objectResetters->setup([]);
+        self::assertCount(0, [...$objectResetters->resetters()]);
+    }
+
+    #[DataProvider('dataProviderResetServiceException')]
+    public function testResetServiceException($id, $containerGotResult, iterable $setup, string $expectExceptionMessage): void
+    {
+        $this->expectException(ResetterExceptionInterface::class);
+        $this->expectExceptionMessageMatches($expectExceptionMessage);
+
+        $containerMock = $this->createMock(ContainerInterface::class);
+        $containerMock->method('get')
+            ->with($id)
+            ->willReturn($containerGotResult)
+        ;
+
+        $objectResetters = new ObjectResetters($containerMock);
+        $objectResetters->setup($setup);
+        $objectResetters->reset();
+    }
+
+    public static function dataProviderResetServiceException(): Generator
+    {
+        yield 'service is non-object' => [
+            'id' => 'foo',
+            'containerGotResult' => 'str',
+            'setup' => ['foo' => 'doReset'],
+            'expectExceptionMessage' => '/Entry with container identifier \'foo\' should return type "object"/',
+        ];
+
+        yield 'service has not public reset method' => [
+            'id' => stdClass::class,
+            'containerGotResult' => new stdClass(),
+            'setup' => [stdClass::class => 'doReset'],
+            'expectExceptionMessage' => '/^Resetter must be is.*existing public method in class "stdClass" class.+Got: \'doReset\' as type "string"/',
+        ];
+    }
+
+    #[DataProvider('dataProviderResetService')]
+    public function testResetService(callable|string $resetter, string $expectFlushesValue): void
+    {
+        $foo = new Fixtures\Foo();
+        $foo->foo = 'init long string';
+
+        $containerMock = $this->createMock(ContainerInterface::class);
+        $containerMock->method('get')
+            ->with(Fixtures\Foo::class)
+            ->willReturn($foo)
+        ;
+
+        $objectResetters = new ObjectResetters($containerMock);
+        $objectResetters->setup([Fixtures\Foo::class => $resetter]);
+        $objectResetters->reset();
+
+        self::assertEquals($expectFlushesValue, $foo->foo);
+    }
+
+    public static function dataProviderResetService(): Generator
+    {
+        yield 'public static method in class' => [
+            'resetter' => [Fixtures\FooResetter::class, 'doReset'],
+            'expectFlushesValue' => 'foo',
+        ];
+
+        yield 'resetter as function' => [
+            'resetter' => '\Tests\ObjectResetters\Fixtures\resetFoo',
+            'expectFlushesValue' => 'fn',
+        ];
+
+        yield 'resetter as \Closure' => [
+            'resetter' => static function (Fixtures\Foo $foo) {
+                $foo->foo = 'closure empty';
+            },
+            'expectFlushesValue' => 'closure empty',
+        ];
+
+        yield 'resetter as method name in object class' => [
+            'resetter' => 'flush',
+            'expectFlushesValue' => 'null',
+        ];
+    }
+}


### PR DESCRIPTION
- Fix #591 
---

Некоторые сервисы контейнера которые разрешаются как синглтон и являются объектом, т.е. создаются один раз и после этого возвращается контейнером один и тот же экземпляр класса, могут требовать сброса своего состояния в долгоживущих процессах.

---

Поддерживается два варианта конфигурирования ресеттеров:
1. Автоматическое конфигурирование ресетеров через определения контейнера:
    1. `\Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire::setResetter(callable|string $resetter)`.
    2. `\Kaspi\DiContainer\DiDefinition\DiDefinitionRuntime::setResetter(callable|string $resetter)`.
    3. Объект реализует интерфейс `\Kaspi\DiContainer\Interfaces\ResetInterface`.
4. Ручная настройка нужных ресеттеров через `\Kaspi\DiContainer\DiDefinition\DiDefinitionAutowire` и PHP класс реализующий интерфейс `\Kaspi\DiContainer\Interfaces\ObjectResettersInterface`. 

Следует выбрать только один из вышеперечисленных вариантов конфигурации.

**При автоматическом конфигурировании ресетеров** необходимо чтобы в конфигурации контейнера параметр `\Kaspi\DiContainer\DiContainerConfig::$isConfigureObjectResettersFromDefinitions` был установлен `true`.
```php
// config/di_services.php
use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
use App\Services\{Foo, Bar, Baz};

use function Kaspi\DiContainer\{diAutowire, diRuntime};

return static function (DefinitionsConfiguratorInterface $configurator): Generator {
    yield diAutowire(Foo::class)
            // ресетер через callback функцию.
       ->setResetter(static function (Foo $foo): void {
                // ...
       });

    yield diAutowire(Bar::class)
            // ресетер через публичный метод класса
        ->setResetter('methodName');

    yield diAutowire(Baz::class)
            // ресетер через статический метод класса
        ->setResetter([Baz::class, 'anyStaticMethod']);
};
```

**Ручная настройка ресетров** может быть выполнена в конфигурационном файле через хелпер функцию `diAutowire` с указанием параметра `$isSingleton = true`, для класса который обязательно должен реализовать интерфейс  `\Kaspi\DiContainer\Interfaces\ObjectResettersInterface`, для этих целей  можно использовать уже готовый PHP класс из библиотеки `\Kaspi\DiContainer\ObjectResetters`:
```php
// config/di_resetters.php
use Generator;
use Kaspi\DiContainer\ObjectResetters;
use App\Services\{Foo, Bar, Baz};

use function Kaspi\DiContainer\diAutowire;

return static function (): Generator {
    yield diAutowire(ObjectResetters::class, isSingleton: true)
        ->setup('setup', [
            // ресетер через callback функцию.
            Foo::class => static function (Foo $foo): void {
                // ...
            },
            // ресетер через публичный метод класса
            Bar::class => 'methodName',
            // ресетер через статический метод класса
            Baz::class => [Baz::class, 'anyStaticMethod'],
       ]);
};
```