### PR TITLE
Soft deprecate method `DefinitionsConfiguratorInterface::findTaggedDefinition()`.

### DIFF
--- a/docs/08-definitions-configurator.md
+++ b/docs/08-definitions-configurator.md
@@ -83,7 +83,7 @@ return static function (DefinitionsConfiguratorInterface $configurator): void {
 
 ## Получить коллекцию определений по тегу.
 ```php
-DefinitionsConfiguratorInterface::findTaggedDefinition(
+DefinitionsConfiguratorInterface::findTaggedDefinitions(
     string $tag
 ): iterable
 ```
@@ -91,7 +91,7 @@ DefinitionsConfiguratorInterface::findTaggedDefinition(
 - `$tag` – имя тега.
 
 > [!NOTE]
-> Важно: определение будет получено если оно было добавлено раньше вызова метода `DefinitionsConfiguratorInterface::findTaggedDefinition()`.
+> Важно: определение будет получено если оно было добавлено раньше вызова метода `DefinitionsConfiguratorInterface::findTaggedDefinitions()`.
 
 
 > [!TIP]
@@ -108,7 +108,7 @@ use function Kaspi\DiContainer\diAutowire;
 
 return static function (DefinitionsConfiguratorInterface $configurator): void {
     
-    foreach ($configurator->findTaggedDefinition(FooInterface::class) as $id => $definition) {
+    foreach ($configurator->findTaggedDefinitions(FooInterface::class) as $id => $definition) {
         $definition->setup('setClient', diAutowire(Client::class));
     }
 

--- a/src/DiContainer/DefinitionsConfigurator.php
+++ b/src/DiContainer/DefinitionsConfigurator.php
@@ -101,6 +101,11 @@ final class DefinitionsConfigurator implements DefinitionsConfiguratorInterface
 
     public function findTaggedDefinition(string $tag): iterable
     {
+        yield from $this->findTaggedDefinitions($tag);
+    }
+
+    public function findTaggedDefinitions(string $tag): iterable
+    {
         if (isset($this->cacheOfTaggedDefinitions[$tag])) {
             yield from $this->cacheOfTaggedDefinitions[$tag];
         }

--- a/src/DiContainer/Interfaces/DefinitionsConfiguratorInterface.php
+++ b/src/DiContainer/Interfaces/DefinitionsConfiguratorInterface.php
@@ -47,9 +47,19 @@ interface DefinitionsConfiguratorInterface extends ResetInterface
     /**
      * @param non-empty-string $tag
      *
+     * @deprecated is deprecated since version 4.6 and will be removed since version 5.0.
+     * Use `\Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface::findTaggedDefinitions()`.
+     *
      * @return iterable<non-empty-string, DiTaggedDefinitionInterface>
      */
     public function findTaggedDefinition(string $tag): iterable;
+
+    /**
+     * @param non-empty-string $tag
+     *
+     * @return iterable<non-empty-string, DiTaggedDefinitionInterface>
+     */
+    public function findTaggedDefinitions(string $tag): iterable;
 
     /**
      * Loads definitions from configuration files.

--- a/tests/DefinitionsLoader/DefinitionsConfigurator/DefinitionsConfiguratorFindTaggedDefinitionsTest.php
+++ b/tests/DefinitionsLoader/DefinitionsConfigurator/DefinitionsConfiguratorFindTaggedDefinitionsTest.php
@@ -91,13 +91,13 @@ class DefinitionsConfiguratorFindTaggedDefinitionsTest extends DefinitionsConfig
         ;
 
         /** @var array<class-string, DiDefinitionAutowire> $definitions */
-        $definitions = [...$this->configurator->findTaggedDefinition(QuxInterface::class)];
+        $definitions = [...$this->configurator->findTaggedDefinitions(QuxInterface::class)];
 
         self::assertCount(2, $definitions);
         self::assertEquals(Bar::class, $definitions[Bar::class]->getDefinition()->getName());
         self::assertEquals(Baz::class, $definitions[Baz::class]->getDefinition()->getName());
 
-        $secondDefinitions = [...$this->configurator->findTaggedDefinition('tags.one')];
+        $secondDefinitions = [...$this->configurator->findTaggedDefinitions('tags.one')];
         self::assertCount(4, $secondDefinitions);
 
         // configured via attribute
@@ -138,11 +138,37 @@ class DefinitionsConfiguratorFindTaggedDefinitionsTest extends DefinitionsConfig
         ;
 
         /** @var array<class-string, DiDefinitionValue> $definitions */
-        $definitions = [...$this->configurator->findTaggedDefinition('tags.emails')];
+        $definitions = [...$this->configurator->findTaggedDefinitions('tags.emails')];
 
         self::assertCount(2, $definitions);
 
         self::assertEquals('admin@example.com', $definitions['email.admin']->getDefinition());
         self::assertEquals([Maker::class, 'managerEmail'], $definitions['email.manager']->getDefinition());
+    }
+
+    public function testDeprecatedFindTaggedDefinitions(): void
+    {
+        $this->definitionsLoaderMock->method('definitions')
+            ->willReturnCallback(function () {
+                yield 'foo.bar' => diValue('foo@bar')
+                    ->bindTag('tags.one')
+                ;
+
+                yield 'bar.baz' => diValue('bar@baz')
+                    ->bindTag('tags.two')
+                ;
+
+                yield 'qux.foo' => diValue('qux@foo')
+                    ->bindTag('tags.one')
+                ;
+            })
+        ;
+
+        $definitions = [...$this->configurator->findTaggedDefinition('tags.one')];
+
+        self::assertCount(2, $definitions);
+
+        self::assertEquals('foo@bar', $definitions['foo.bar']->getDefinition());
+        self::assertEquals('qux@foo', $definitions['qux.foo']->getDefinition());
     }
 }

--- a/tests/DefinitionsLoader/DefinitionsLoaderWithConfiguratorTest.php
+++ b/tests/DefinitionsLoader/DefinitionsLoaderWithConfiguratorTest.php
@@ -241,7 +241,7 @@ use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
 use Tests\DefinitionsLoader\Fixtures\TaggedInterface\QuxInterface;
         
 return static function (DefinitionsConfiguratorInterface $configurator): void {
-    foreach ($configurator->findTaggedDefinition(QuxInterface::class) as $def) {
+    foreach ($configurator->findTaggedDefinitions(QuxInterface::class) as $def) {
         $def->bindTag("tags.as_interface");    
     }
 };',
@@ -275,7 +275,7 @@ use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
 return static function (DefinitionsConfiguratorInterface $configurator): void {
     $collection = [];
 
-    foreach ($configurator->findTaggedDefinition("tags.one") as $id => $def) {
+    foreach ($configurator->findTaggedDefinitions("tags.one") as $id => $def) {
         $collection[$id] = $def;    
     }
     
@@ -313,7 +313,7 @@ return static function (DefinitionsConfiguratorInterface $configurator): void {
 use Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface;
         
 return static function (DefinitionsConfiguratorInterface $configurator): void {
-    foreach ($configurator->findTaggedDefinition("tags.one") as $def) {
+    foreach ($configurator->findTaggedDefinitions("tags.one") as $def) {
         $def->bindTag("tags.two");
     }
 };',
@@ -353,7 +353,7 @@ return static function (DefinitionsConfiguratorInterface $configurator): void {
         ;
         self::assertEquals(
             [],
-            [...$configurator->findTaggedDefinition(ContainerInterface::class)]
+            [...$configurator->findTaggedDefinitions(ContainerInterface::class)]
         );
     }
 }

--- a/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
+++ b/tests/DefinitionsLoader/ImportDiRuntime/DefinitionsLoaderImportDiRuntimeTest.php
@@ -100,7 +100,7 @@ class DefinitionsLoaderImportDiRuntimeTest extends TestCase
         vfsStream::setup('root', structure: [
             'services.php' => '<?php
 return static function (\Kaspi\DiContainer\Interfaces\DefinitionsConfiguratorInterface $configurator) {
-    foreach ($configurator->findTaggedDefinition("tags.bar_service") as $definition) {
+    foreach ($configurator->findTaggedDefinitions("tags.bar_service") as $definition) {
         $definition->bindTag("tags.config");
     }
 };',


### PR DESCRIPTION
- Resolve #676 